### PR TITLE
✨ Featue: #13 HealthKitManager 구현

### DIFF
--- a/StopSun/StopSun/Managers/HealthKitManager.swift
+++ b/StopSun/StopSun/Managers/HealthKitManager.swift
@@ -6,28 +6,141 @@
 //
 
 import Foundation
+import HealthKit
 
 /// HealthKit 데이터 관리자
+///
+/// Apple Watch의 `timeInDaylight` 데이터를 조회하고
+/// Background Delivery를 통해 실시간 업데이트를 수신합니다.
+///
 final class HealthKitManager: HealthKitManagerProtocol {
+   
+    // MARK: - Properties
+    private let healthStore = HKHealthStore()
+    private let timeInDaylightType = HKQuantityType(.timeInDaylight)
     
-    var isAvailable: Bool { true }
-    var isAuthorized: Bool { false }
+    var isAvailable: Bool {
+        HKHealthStore.isHealthDataAvailable()
+    }
+    
+    var isAuthorized: Bool {
+        let status = healthStore.authorizationStatus(for: timeInDaylightType)
+        return true
+    }
+    
+    // MARK: - Authorization
     
     func requestAuthorization() async throws {
         // TODO: 구현
+        guard isAvailable else {
+            throw HealthKitError.notAvailable // TODO: - 에러 핸들러 처리 필요
+        }
+        
+        let typesToRead: Set<HKObjectType> = [timeInDaylightType]
+        
+        try await healthStore.requestAuthorization(toShare: [], read: typesToRead)
     }
+    
+    // MARK: - Fetch Data
     
     func fetchTodayTimeInDaylight() async throws -> [TimeInDaylight] {
         // TODO: 구현
-        return []
+        let calendar = Calendar.current
+        let startOfDay = calendar.startOfDay(for: Date())
+        let now = Date()
+        
+        return try await fetchTimeInDaylight(from: startOfDay, to: now)
     }
     
     func fetchTimeInDaylight(from start: Date, to end: Date) async throws -> [TimeInDaylight] {
-        // TODO: 구현
-        return []
+        guard isAvailable else {
+            throw HealthKitError.notAvailable // TODO: - 에러 핸들러 처리 필요
+        }
+        
+        let predicate = HKQuery.predicateForSamples(
+            withStart: start,
+            end: end,
+            options: .strictStartDate
+        )
+        
+        let sortDescriptor = NSSortDescriptor(
+            key: HKSampleSortIdentifierStartDate,
+            ascending: true
+        )
+        
+        return try await withCheckedThrowingContinuation { continuation in
+            let query = HKSampleQuery(
+                sampleType: timeInDaylightType, predicate: predicate, limit: HKObjectQueryNoLimit, sortDescriptors: [sortDescriptor]) { _, samples, error in
+                    if let error {
+                        continuation.resume(throwing: error)
+                        return
+                    }
+                    
+                    let results = (samples as? [HKQuantitySample] ?? []).map { sample in
+                        TimeInDaylight(
+                            id: sample.uuid,
+                            startTime: sample.startDate,
+                            endTime: sample.endDate
+                        )
+                    }
+                    continuation.resume(returning: results)
+                }
+            healthStore.execute(query)
+        }
     }
     
+    // MARK: - Background Delivery
+    
     func enableBackgroundDelivery() async throws {
-        // TODO: 구현
+        guard isAvailable else {
+            throw HealthKitError.notAvailable // TODO: - 에러 핸들링 처리 필요
+        }
+        
+        try await healthStore.enableBackgroundDelivery(for: timeInDaylightType, frequency: .immediate)
+        
+        setupObserverQuery()
     }
+    
+    // MARK: - Observer Query
+
+    private func setupObserverQuery() {
+        let query = HKObserverQuery(
+            sampleType: timeInDaylightType,
+            predicate: nil
+        ) { _, completionHandler, error in
+            defer { completionHandler() }
+            
+            guard error == nil else { return }
+            
+            // TODO: - NotificationCenter 파일 분리 필요
+            NotificationCenter.default.post(name: .newTimeInDaylightAvailable, object: nil)
+        }
+        
+        healthStore.execute(query)
+    }
+}
+
+// MARK: - Error
+
+enum HealthKitError: Error { // TODO: - 분리 필요
+    case notAvailable
+    case notAuthorized
+    case queryFailed
+    
+    var errorDescription: String? {
+        switch self {
+        case .notAvailable:
+            return "HealthKit is not available on this device"
+        case .notAuthorized:
+            return "HealthKit authorization denied"
+        case .queryFailed:
+            return "HealthKit query failed"
+        }
+    }
+}
+
+// MARK: - Notification Names
+
+extension Notification.Name { // TODO: - 분리 필요
+    static let newTimeInDaylightAvailable = Notification.Name("newTimeInDaylightAvailable")
 }

--- a/StopSun/StopSun/Views/Tests/HealthKit/HealthKitTestView.swift
+++ b/StopSun/StopSun/Views/Tests/HealthKit/HealthKitTestView.swift
@@ -1,0 +1,167 @@
+//
+//  HealthKitTestView.swift
+//  StopSun
+//
+//  Created by J on 1/29/26.
+//
+
+import SwiftUI
+
+///  테스트용 - 나중에 삭제
+import SwiftUI
+
+struct HealthKitTestView: View {
+    @StateObject private var viewModel = HealthKitTestViewModel()
+    
+    var body: some View {
+        NavigationStack {
+            List {
+                // MARK: - 상태
+                Section("상태") {
+                    HStack {
+                        Text("HealthKit 사용 가능")
+                        Spacer()
+                        Text(viewModel.isAvailable ? "✅" : "❌")
+                    }
+                    
+                    HStack {
+                        Text("권한 요청됨")
+                        Spacer()
+                        Text(viewModel.isAuthorized ? "✅" : "❌")
+                    }
+                    
+                    HStack {
+                        Text("Background Delivery")
+                        Spacer()
+                        Text(viewModel.isBackgroundDeliveryEnabled ? "✅" : "❌")
+                    }
+                }
+                
+                // MARK: - Background Delivery 모니터링
+                Section("Background Delivery 모니터링") {
+                    HStack {
+                        Text("수신 횟수")
+                        Spacer()
+                        Text("\(viewModel.backgroundDeliveryCount)회")
+                            .foregroundStyle(.blue)
+                    }
+                    
+                    HStack {
+                        Text("마지막 수신")
+                        Spacer()
+                        if let time = viewModel.lastBackgroundDeliveryTime {
+                            Text(formatDateTime(time))
+                                .foregroundStyle(.green)
+                        } else {
+                            Text("없음")
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+                
+                // MARK: - 액션
+                Section("액션") {
+                    Button("권한 요청") {
+                        Task {
+                            await viewModel.requestAuthorization()
+                        }
+                    }
+                    .disabled(viewModel.isAuthorized)
+                    
+                    Button("오늘 데이터 조회") {
+                        Task {
+                            await viewModel.fetchTodayData()
+                        }
+                    }
+                    .disabled(!viewModel.isAuthorized)
+                }
+                
+                // MARK: - 기간별 조회
+                Section("기간별 조회") {
+                    DatePicker("시작일", selection: $viewModel.startDate, displayedComponents: .date)
+                    DatePicker("종료일", selection: $viewModel.endDate, displayedComponents: .date)
+                    
+                    Button("기간 데이터 조회") {
+                        Task {
+                            await viewModel.fetchPeriodData()
+                        }
+                    }
+                    .disabled(!viewModel.isAuthorized)
+                }
+                
+                // MARK: - 에러
+                if let errorMessage = viewModel.errorMessage {
+                    Section("에러") {
+                        Text(errorMessage)
+                            .foregroundStyle(.red)
+                    }
+                }
+                
+                // MARK: - 오늘 데이터
+                Section("오늘 TimeInDaylight (\(viewModel.todayData.count)건)") {
+                    if viewModel.isLoading {
+                        ProgressView()
+                    } else if viewModel.todayData.isEmpty {
+                        Text("데이터 없음")
+                            .foregroundStyle(.secondary)
+                    } else {
+                        ForEach(viewModel.todayData) { item in
+                            timeInDaylightRow(item)
+                        }
+                    }
+                }
+                
+                // MARK: - 기간 데이터
+                Section("기간별 TimeInDaylight (\(viewModel.periodData.count)건)") {
+                    if viewModel.isLoading {
+                        ProgressView()
+                    } else if viewModel.periodData.isEmpty {
+                        Text("데이터 없음")
+                            .foregroundStyle(.secondary)
+                    } else {
+                        ForEach(viewModel.periodData) { item in
+                            timeInDaylightRow(item)
+                        }
+                    }
+                }
+            }
+            .navigationTitle("HealthKit 테스트")
+        }
+    }
+    
+    // MARK: - Helper
+    
+    @ViewBuilder
+    private func timeInDaylightRow(_ item: TimeInDaylight) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("\(formatDate(item.startTime)) ~ \(formatTime(item.endTime))")
+                .font(.subheadline)
+            Text("노출 시간: \(String(format: "%.1f", item.durationMinutes))분")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 4)
+    }
+    
+    private func formatDate(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MM/dd HH:mm"
+        return formatter.string(from: date)
+    }
+    
+    private func formatTime(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm"
+        return formatter.string(from: date)
+    }
+    
+    private func formatDateTime(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm:ss"
+        return formatter.string(from: date)
+    }
+}
+
+#Preview {
+    HealthKitTestView()
+}

--- a/StopSun/StopSun/Views/Tests/HealthKit/HealthKitTestViewModel.swift
+++ b/StopSun/StopSun/Views/Tests/HealthKit/HealthKitTestViewModel.swift
@@ -1,0 +1,145 @@
+//
+//  HealthKitTestViewModel.swift
+//  StopSun
+//
+//  Created by J on 1/29/26.
+//
+
+import Foundation
+
+@MainActor
+final class HealthKitTestViewModel: ObservableObject {
+    
+    // MARK: - Published
+    @Published private(set) var isAuthorized: Bool = false
+    @Published private(set) var isBackgroundDeliveryEnabled = false
+    @Published private(set) var lastBackgroundDeliveryTime: Date?
+    @Published private(set) var backgroundDeliveryCount = 0
+    @Published private(set) var todayData: [TimeInDaylight] = []
+    @Published private(set) var periodData: [TimeInDaylight] = []
+    @Published private(set) var errorMessage: String?
+    @Published private(set) var isLoading = false
+    
+    @Published var startDate = Calendar.current.date(byAdding: .day, value: -7, to: Date()) ?? Date()
+    @Published var endDate = Date()
+    
+    // MARK: - Dependencies
+    private let healthKitManager: any HealthKitManagerProtocol
+    
+    var isAvailable: Bool {
+        healthKitManager.isAvailable
+    }
+    
+    // MARK: - Init
+    
+    init() {
+        self.healthKitManager = DIContainer.shared.healthKit
+        setupObservers()
+        
+        Task {
+            await checkAuthorizationAndSetup()
+        }
+        
+    }
+    
+    // 테스트용
+    init(healthKitManager: any HealthKitManagerProtocol) {
+        self.healthKitManager = healthKitManager
+        setupObservers()
+        
+        Task {
+            await checkAuthorizationAndSetup()
+        }
+    }
+    
+    private func checkAuthorizationAndSetup() async {
+        // 이미 권한 있으면 바로 설정
+        guard healthKitManager.isAvailable else { return }
+        
+        // 권한 요청 (이미 허용됐으면 바로 완료)
+        do {
+            try await healthKitManager.requestAuthorization()
+            isAuthorized = true
+            
+            try await healthKitManager.enableBackgroundDelivery()
+            isBackgroundDeliveryEnabled = true
+            Log.info("초기화 완료")
+        } catch {
+            Log.error("초기화 실패: \(error.localizedDescription)")
+        }
+    }
+    
+    private func setupObservers() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleBackgroundDelivery),
+            name: .newTimeInDaylightAvailable,
+            object: nil
+        )
+    }
+    
+    @objc nonisolated private func handleBackgroundDelivery() {
+        Task { @MainActor in
+            lastBackgroundDeliveryTime = Date()
+            backgroundDeliveryCount += 1
+            print("🔔 [ViewModel] Background Delivery 수신: \(Date())")
+        }
+    }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+    
+    // MARK: - Methods
+    
+    func requestAuthorization() async {
+        errorMessage = nil
+        do {
+            try await healthKitManager.requestAuthorization()
+            isAuthorized = true
+            
+            try await healthKitManager.enableBackgroundDelivery()
+            isBackgroundDeliveryEnabled = true
+            Log.info("Background Delivery 활성화")
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+    
+    func enableBackgroundDelivery() async {
+        errorMessage = nil
+        do {
+            try await healthKitManager.enableBackgroundDelivery()
+            isBackgroundDeliveryEnabled = true
+            Log.info("Background Delivery 활성화됨")
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+    
+    func fetchTodayData() async {
+        errorMessage = nil
+        isLoading = true
+        
+        do {
+            todayData = try await healthKitManager.fetchTodayTimeInDaylight()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        
+        isLoading = false
+    }
+    
+    func fetchPeriodData() async {
+        errorMessage = nil
+        isLoading = true
+        
+        do {
+            periodData = try await healthKitManager.fetchTimeInDaylight(from: startDate, to: endDate)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        
+        isLoading = false
+    }
+}


### PR DESCRIPTION
## ✨ What’s this PR?
close #13 

### 🧶 주요 변경 내용

#### `HealthKitManager`
- timeInDaylight 데이터 조회 (오늘/기간별)
- Background Delivery 및 ObserverQuery 설정
- 새 데이터 도착 시 NotificationCenter 이벤트 발송

#### `HealthKitTestView` , `HealthKitViewModel` (테스트용)
- 권한 요청 및 상태 확인
- Background Delivery 모니터링
- 오늘 데이터 조회
- 기간별 데이터 조회

---

### 📸 스크린샷 

<img width="200" alt="예시 이미지" src="https://github.com/user-attachments/assets/3fc3cc8e-7a2a-43b2-b8b2-e8c305cd41eb">
<img width="200" alt="예시 이미지" src="https://github.com/user-attachments/assets/e0b96c77-fbec-445f-aa12-e24a8226a129">

---

### 🧪 테스트 / 검증 내역

- [x] 실기기에서 정상 작동 확인
- [x] timeInDaylight 데이터 조회 확인
- [x] Background Delivery 트리거 확인 → 건강 정보에서 직접 추가하면 바로 들어오고, 실제 데이터도 잘 들어옴!

---

### 💬 기타 공유 사항

#### ✅ *TODO 처리해놓은 곳*
- [ ] Notification.Name 파일 분리
- [ ] HealthKitError 파일 분리
- [x] ErrorHandler 만들면 에러 처리

#### ✅ *isAuthorized가 항상 true인 이유*
Apple 프라이버시 정책상 HealthKit read 권한 상태는 확인이 불가하기 때문! 
그래서 그냥 형식상 일단 변수가 존재하긴 합니다만 항상 true를 반환하도록 해놓았습니다.

>As part of the privacy protections, your app doesn’t know whether someone granted or denied permission to read data from HealthKit. If they denied permission, attempts to read data from HealthKit return only samples that your app successfully saved to the HealthKit store. 

`authorizationStatus(for:)`는 write 권한만 반환합니다.. read 권한 여부가 알려지면 "사용자가 해당 건강 데이터를 가지고 있다"라는 정보가 노출될 수 있기 때문에 실제 권한 여부는 fetch 시 빈 결과로 판단해야한다고 하네요.

그래서 앱 구현할 때도 권한 요청 → 데이터 fetch → 데이터 있으면 보여주고, 없으면 '데이터 없음' 으로 처리한다고 하네요. (제가 써본 스트레스 앱도 그렇긴 했던 것 같습니다)

자세한 내용은 제가 링크 걸어놓은 애플 공식 문서에서 읽어보실 수 있습니다 ~

- [Authorizing access to health data](https://developer.apple.com/documentation/healthkit/authorizing-access-to-health-data#3858794)
- [authorizationStatus(for:)](https://developer.apple.com/documentation/healthkit/hkhealthstore/authorizationstatus(for:))