### PR TITLE
✨ Feature: #15 WeatherManager 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots/**/*.png
 fastlane/test_output
+
+#xcconfig
+Config.xcconfig

--- a/StopSun/Shared/Resources/Models/Response/HourlyForcast.swift
+++ b/StopSun/Shared/Resources/Models/Response/HourlyForcast.swift
@@ -15,7 +15,10 @@ import Foundation
 /// let forecast = HourlyForecast(hour: 14, uvIndex: 8.5, ...)
 /// print("오후 2시 UV: \(forecast.uvIndex)")
 /// ```
-struct HourlyForecast: Equatable {
+struct HourlyForecast: Equatable, Identifiable {
+    
+    /// UUID
+    let id = UUID()
     
     /// 시간 (0-23)
     let hour: Int

--- a/StopSun/StopSun.xcodeproj/project.pbxproj
+++ b/StopSun/StopSun.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		058BD68C2E793E3B00AAF08B /* StopSunWatch Watch App.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 058BD6822E793E3A00AAF08B /* StopSunWatch Watch App.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		804E4B5A2F2C82E70019E4EE /* Moya in Frameworks */ = {isa = PBXBuildFile; productRef = 804E4B592F2C82E70019E4EE /* Moya */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -75,6 +76,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				804E4B5A2F2C82E70019E4EE /* Moya in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -130,6 +132,7 @@
 			);
 			name = StopSun;
 			packageProductDependencies = (
+				804E4B592F2C82E70019E4EE /* Moya */,
 			);
 			productName = StopSun;
 			productReference = 058BD6702E793E2C00AAF08B /* StopSun.app */;
@@ -184,6 +187,9 @@
 			);
 			mainGroup = 058BD6672E793E2C00AAF08B;
 			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				804E4B582F2C82E70019E4EE /* XCRemoteSwiftPackageReference "Moya" */,
+			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 058BD6712E793E2C00AAF08B /* Products */;
 			projectDirPath = "";
@@ -240,6 +246,8 @@
 /* Begin XCBuildConfiguration section */
 		058BD6792E793E2D00AAF08B /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 058BD6722E793E2C00AAF08B /* StopSun */;
+			baseConfigurationReferenceRelativePath = Config.xcconfig;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -532,6 +540,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		804E4B582F2C82E70019E4EE /* XCRemoteSwiftPackageReference "Moya" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Moya/Moya";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 15.0.3;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		804E4B592F2C82E70019E4EE /* Moya */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 804E4B582F2C82E70019E4EE /* XCRemoteSwiftPackageReference "Moya" */;
+			productName = Moya;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 058BD6682E793E2C00AAF08B /* Project object */;
 }

--- a/StopSun/StopSun.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/StopSun/StopSun.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,42 @@
+{
+  "originHash" : "8f916f5d4326b71e39effcaaa3b5d19d894467a03c60c9c5033a4bfc3cfd2d9c",
+  "pins" : [
+    {
+      "identity" : "alamofire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Alamofire/Alamofire.git",
+      "state" : {
+        "revision" : "7be73f6c2b5cd90e40798b06ebd5da8f9f79cf88",
+        "version" : "5.11.0"
+      }
+    },
+    {
+      "identity" : "moya",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Moya/Moya",
+      "state" : {
+        "revision" : "c263811c1f3dbf002be9bd83107f7cdc38992b26",
+        "version" : "15.0.3"
+      }
+    },
+    {
+      "identity" : "reactiveswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ReactiveCocoa/ReactiveSwift.git",
+      "state" : {
+        "revision" : "c43bae3dac73fdd3cb906bd5a1914686ca71ed3c",
+        "version" : "6.7.0"
+      }
+    },
+    {
+      "identity" : "rxswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ReactiveX/RxSwift.git",
+      "state" : {
+        "revision" : "5004a18539bd68905c5939aa893075f578f4f03d",
+        "version" : "6.9.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/StopSun/StopSun/Application/StopSunApp.swift
+++ b/StopSun/StopSun/Application/StopSunApp.swift
@@ -11,8 +11,7 @@ import SwiftUI
 struct StopSunApp: App {
     var body: some Scene {
         WindowGroup {
-//            ContentView()
-            WeatherTestView()
+            ContentView()
         }
     }
 }

--- a/StopSun/StopSun/Application/StopSunApp.swift
+++ b/StopSun/StopSun/Application/StopSunApp.swift
@@ -11,7 +11,8 @@ import SwiftUI
 struct StopSunApp: App {
     var body: some Scene {
         WindowGroup {
-            ContentView()
+//            ContentView()
+            WeatherTestView()
         }
     }
 }

--- a/StopSun/StopSun/Extensions/Date+Extensions.swift
+++ b/StopSun/StopSun/Extensions/Date+Extensions.swift
@@ -1,0 +1,44 @@
+//
+//  Date+Extensions.swift
+//  StopSun
+//
+//  Created by J on 1/30/26.
+//
+
+import Foundation
+
+// MARK: - Date Extensions
+
+extension Date {
+    
+    /// API 요청용 날짜 문자열 (yyyy-MM-dd)
+    var toAPIDateString: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: self)
+    }
+}
+
+// MARK: - String Extensions
+
+extension String {
+    
+    /// WeatherAPI 시간 문자열에서 시간 추출
+    /// "2025-01-27 14:00" → 14
+    var toHour: Int? {
+        let components = self.split(separator: " ")
+        guard components.count >= 2 else { return nil }
+        
+        let timePart = components[1]
+        let hourString = timePart.split(separator: ":").first
+        return hourString.flatMap { Int($0) }
+    }
+    
+    /// WeatherAPI 시간 문자열을 Date로 변환
+    /// "2025-01-27 14:00" → Date
+    var toDate: Date? {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HH:mm"
+        return formatter.date(from: self)
+    }
+}

--- a/StopSun/StopSun/Info.plist
+++ b/StopSun/StopSun/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>WeatherAPIKey</key>
+	<string>$(WEATHER_API_KEY)</string>
 	<key>NSUserNotificationUsageDescription</key>
 	<string>선크림 알림을 위해 알림 권한이 필요합니다.</string>
 	<key>UIBackgroundModes</key>

--- a/StopSun/StopSun/Managers/Mocks/MockManagers.swift
+++ b/StopSun/StopSun/Managers/Mocks/MockManagers.swift
@@ -29,6 +29,10 @@ final class MockHealthKitManager: HealthKitManagerProtocol {
 // MARK: - MockWeatherManager
 
 final class MockWeatherManager: WeatherManagerProtocol {
+    func fetchCurrentUVIndex(for location: LocationInfo) async throws -> Double {
+        return 2.0
+    }
+    
     func fetchCurrentWeather(for location: LocationInfo) async throws -> LocationWeather {
         return LocationWeather(
             location: location,
@@ -50,7 +54,7 @@ final class MockLocationManager: LocationManagerProtocol {
     func requestAuthorization() async {}
     
     func getCurrentLocation() async throws -> LocationInfo {
-        return .mockSeoul
+        return .mockPohang
     }
     
     func startMonitoringSignificantLocationChanges() {}

--- a/StopSun/StopSun/Managers/Network/WeatherAPI.swift
+++ b/StopSun/StopSun/Managers/Network/WeatherAPI.swift
@@ -1,0 +1,95 @@
+//
+//  WeatherAPI.swift
+//  StopSun
+//
+//  Created by J on 1/30/26.
+//
+
+import Foundation
+import Moya
+
+/// WeatherAPI 엔드포인트 정의
+enum WeatherAPI {
+    /// 현재 날씨만
+    case current(lat: Double, lon: Double)
+    
+    /// 현재 날씨 + 시간별 예보
+    case forecast(lat: Double, lon: Double, days: Int)
+    
+    /// 과거 날씨
+    case history(lat: Double, lon: Double, date: String)
+}
+
+extension WeatherAPI: TargetType {
+    var baseURL: URL {
+        URL(string: "https://api.weatherapi.com/v1")!
+    }
+    
+    var path: String {
+        switch self {
+        case .current:
+            return "/current.json"
+        case .forecast:
+            return "/forecast.json"
+        case .history:
+            return "/history.json"
+        }
+    }
+    
+    var method: Moya.Method {
+        .get
+    }
+    
+    var task: Moya.Task {
+         switch self {
+         case .current(let lat, let lon):
+             return .requestParameters(
+                 parameters: [
+                     "key": WeatherAPIConfig.apiKey,
+                     "q": "\(lat),\(lon)",
+                     "aqi": "no"
+                 ],
+                 encoding: URLEncoding.queryString
+             )
+             
+         case .forecast(let lat, let lon, let days):
+             return .requestParameters(
+                 parameters: [
+                     "key": WeatherAPIConfig.apiKey,
+                     "q": "\(lat),\(lon)",
+                     "days": days,
+                     "aqi": "no",
+                     "alerts": "no"
+                 ],
+                 encoding: URLEncoding.queryString
+             )
+             
+         case .history(let lat, let lon, let date):
+             return .requestParameters(
+                 parameters: [
+                     "key": WeatherAPIConfig.apiKey,
+                     "q": "\(lat),\(lon)",
+                     "dt": date
+                 ],
+                 encoding: URLEncoding.queryString
+             )
+         }
+     }
+     
+     var headers: [String: String]? {
+         ["Content-Type": "application/json"]
+     }
+}
+
+// MARK: - API Config
+
+enum WeatherAPIConfig {
+    static var apiKey: String {
+        guard let key = Bundle.main.infoDictionary?["WeatherAPIKey"] as? String,
+              !key.isEmpty else {
+            Log.fault("WeatherAPIKey not found in Info.plist")
+            fatalError("WeatherAPIKey not found in Info.plist")
+        }
+        return key
+    }
+}

--- a/StopSun/StopSun/Managers/Network/WeatherAPIClient.swift
+++ b/StopSun/StopSun/Managers/Network/WeatherAPIClient.swift
@@ -1,0 +1,65 @@
+//
+//  WeatherAPIClient.swift
+//  StopSun
+//
+//  Created by J on 1/30/26.
+//
+
+import Foundation
+import Moya
+
+/// WeatherAPI 호출 클라이언트
+///
+/// Moya를 통해 WeatherAPI 엔드포인트를 호출합니다.
+/// WeatherManager에서 사용합니다.
+///
+final class WeatherAPIClient {
+    
+    // MARK: - Properties
+    
+    private let provider: MoyaProvider<WeatherAPI>
+    private let decoder: JSONDecoder
+    
+    // MARK: - Init
+    
+    init() {
+        self.provider = MoyaProvider<WeatherAPI>()
+        self.decoder = JSONDecoder()
+    }
+    
+    // MARK: - Request
+    
+    func request(_ target: WeatherAPI) async throws -> WeatherAPIResponse {
+        let response = try await provider.request(target)
+        
+        Log.info("📡 Status Code: \(response.statusCode)")
+        
+        if let json = String(data: response.data, encoding: .utf8) {
+            Log.info("Weather API Response: \(json)")
+        }
+        
+        let data = try response.filterSuccessfulStatusCodes().data
+        
+        do {
+            return try decoder.decode(WeatherAPIResponse.self, from: data)
+        } catch {
+            Log.error("Decoding Error: \(error)")
+            throw WeatherError.decodingFailed
+        }
+    }
+}
+
+extension MoyaProvider {
+    func request(_ target: Target) async throws -> Response {
+        try await withCheckedThrowingContinuation { continuation in
+            self.request(target) { result in
+                switch result {
+                case .success(let response):
+                    continuation.resume(returning: response)
+                case .failure(let error):
+                    continuation.resume(throwing: WeatherError.networkFailed(error.localizedDescription))
+                }
+            }
+        }
+    }
+}

--- a/StopSun/StopSun/Managers/Network/WeatherAPIResponse.swift
+++ b/StopSun/StopSun/Managers/Network/WeatherAPIResponse.swift
@@ -1,0 +1,55 @@
+//
+//  WeatherAPIResponse.swift
+//  StopSun
+//
+//  Created by J on 1/30/26.
+//
+
+import Foundation
+
+/// WeatherAPI 응답 모델
+struct WeatherAPIResponse: Decodable {
+    let location: WeatherAPILocation
+    let current: WeatherAPICurrent?
+    let forecast: WeatherAPIForecast?
+}
+
+struct WeatherAPILocation: Decodable {
+    let name: String
+    let region: String
+    let country: String
+    let lat: Double
+    let lon: Double
+    let localtime: String
+}
+
+struct WeatherAPICurrent: Decodable {
+    let tempC: Double
+    let uv: Double
+    
+    enum CodingKeys: String, CodingKey {
+        case tempC = "temp_c"
+        case uv
+    }
+}
+
+struct WeatherAPIForecast: Decodable {
+    let forecastday: [WeatherAPIForecastDay]
+}
+
+struct WeatherAPIForecastDay: Decodable {
+    let date: String
+    let hour: [WeatherAPIHour]
+}
+
+struct WeatherAPIHour: Decodable {
+    let time: String
+    let tempC: Double
+    let uv: Double
+    
+    enum CodingKeys: String, CodingKey {
+        case time
+        case tempC = "temp_c"
+        case uv
+    }
+}

--- a/StopSun/StopSun/Managers/Protocols/WeatherManagerProtocol.swift
+++ b/StopSun/StopSun/Managers/Protocols/WeatherManagerProtocol.swift
@@ -17,7 +17,13 @@ import Foundation
 ///
 protocol WeatherManagerProtocol {
     
-    /// 현재 날씨 조회
+    /// 현재 UV Index만 조회
+    ///
+    /// - Parameter location: 위치 정보
+    /// - Returns: 현재 UV Index
+    func fetchCurrentUVIndex(for location: LocationInfo) async throws -> Double
+    
+    /// 현재 날씨 + 시간별 예보 조회
     ///
     /// - Parameter location: 위치 정보
     /// - Returns: 현재 날씨 및 시간별 예보

--- a/StopSun/StopSun/Managers/WeatherManager.swift
+++ b/StopSun/StopSun/Managers/WeatherManager.swift
@@ -6,21 +6,103 @@
 //
 
 import Foundation
+import Moya
 
 /// 날씨 API 관리자
+///
+/// WeatherAPI를 통해 현재 및 과거 UV Index를 조회합니다.
+///
 final class WeatherManager: WeatherManagerProtocol {
     
-    func fetchCurrentWeather(for location: LocationInfo) async throws -> LocationWeather {
-        // TODO: 구현
-        return LocationWeather(
-            location: location,
-            currentUVIndex: 0,
-            currentTemperature: 0
+    // MARK: - Properties
+    
+    private let apiClient: WeatherAPIClient
+    
+    // MARK: Init
+    
+    init(apiClient: WeatherAPIClient = WeatherAPIClient()) {
+        self.apiClient = apiClient
+    }
+
+    func fetchCurrentUVIndex(for location: LocationInfo) async throws -> Double {
+        let response = try await apiClient.request(
+            WeatherAPI.current(
+                lat: location.latitude,
+                lon: location.longitude
+            )
         )
+        
+        return response.current?.uv ?? 0.0
+    }
+    
+    func fetchCurrentWeather(for location: LocationInfo) async throws -> LocationWeather {
+        let response = try await apiClient.request(
+            WeatherAPI.forecast(
+                lat: location.latitude,
+                lon: location.longitude,
+                days: 1
+            )
+        )
+        
+        return mapToLocationWeather(response: response, location: location)
     }
     
     func fetchUVIndex(for location: LocationInfo, at date: Date) async throws -> Double {
-        // TODO: 구현
-        return 0
+        let response = try await apiClient.request(
+            WeatherAPI.history(
+                lat: location.latitude,
+                lon: location.longitude,
+                date: date.toAPIDateString
+            )
+        )
+        
+        // 해당 시간대의 UV Index 찾기
+        let hour = Calendar.current.component(.hour, from: date)
+        
+        if let forecastDay = response.forecast?.forecastday.first,
+           let hourData = forecastDay.hour.first(where: { $0.time.toHour == hour }) {
+            return hourData.uv
+        }
+        
+        // 못 찾으면 현재 UV 반환
+        return response.current?.uv ?? 0.0
+    }
+    
+    // MARK: - Private Methods
+    
+    private func mapToLocationWeather(response: WeatherAPIResponse, location: LocationInfo) -> LocationWeather {
+        let hourlyForecasts: [HourlyForecast] = response.forecast?.forecastday.first?.hour.compactMap { hour in
+            guard let hourInt = hour.time.toHour, let timestamp = hour.time.toDate else {
+                return nil
+            }
+            
+            return HourlyForecast(hour: hourInt, uvIndex: hour.uv, temperature: hour.tempC, timestamp: timestamp)
+        } ?? []
+        
+        return LocationWeather(
+            location: location,
+            currentUVIndex: response.current?.uv ?? 0.0,
+            currentTemperature: response.current?.tempC ?? 0.0,
+            hourlyForecasts: hourlyForecasts
+        )
+    }
+}
+
+// MARK: - Errors
+
+enum WeatherError: LocalizedError { // TODO: - 에러 파일 분리
+    case networkFailed(String)
+    case decodingFailed
+    case noData
+    
+    var errorDescription: String? {
+        switch self {
+        case .networkFailed(let message):
+            return "Network error: \(message)"
+        case .decodingFailed:
+            return "Failed to decode weather data"
+        case .noData:
+            return "No weather data available"
+        }
     }
 }

--- a/StopSun/StopSun/Views/Tests/WeatherTestView.swift
+++ b/StopSun/StopSun/Views/Tests/WeatherTestView.swift
@@ -1,0 +1,135 @@
+//
+//  WeatherTestView.swift
+//  StopSun
+//
+//  Created by J on 1/30/26.
+//
+
+import SwiftUI
+
+struct WeatherTestView: View {
+    
+    @StateObject private var viewModel = WeatherTestViewModel()
+    
+    var body: some View {
+        NavigationStack {
+            List {
+                currentUVSection
+                currentWeatherSection
+                hourlyForecastSection
+                historySection
+                errorSection
+            }
+            .navigationTitle("Weather 테스트")
+        }
+    }
+}
+
+// MARK: - Sections
+
+private extension WeatherTestView {
+    
+    var currentUVSection: some View {
+        Section("현재 UV Index") {
+            Button("현재 UV 조회") {
+                Task { await viewModel.fetchCurrentUVIndex() }
+            }
+            
+            if let uv = viewModel.currentUVIndex {
+                row(title: "현재 UV 지수", value: uv.formatted(.number.precision(.fractionLength(1))), color: uvColor(uv))
+            }
+        }
+    }
+    
+    @ViewBuilder
+    var currentWeatherSection: some View {
+        Section("현재 날씨 + 예보") {
+            Button("현재 날씨 조회") {
+                Task { await viewModel.fetchCurrentWeather() }
+            }
+            
+            if viewModel.isLoading {
+                ProgressView()
+            }
+            
+            if let weather = viewModel.currentWeather {
+                row(title: "위치", value: weather.location.cityName ?? "알 수 없음")
+                row(title: "현재 UV 지수", value: weather.currentUVIndex.formatted(.number.precision(.fractionLength(1))), color: uvColor(weather.currentUVIndex))
+                row(title: "현재 온도", value: "\(weather.currentTemperature.formatted(.number.precision(.fractionLength(1))))°C")
+            }
+        }
+    }
+    
+    @ViewBuilder
+    var hourlyForecastSection: some View {
+        if let weather = viewModel.currentWeather, !weather.hourlyForecasts.isEmpty {
+            Section("시간별 UV 지수 (\(weather.hourlyForecasts.count)건)") {
+                ForEach(weather.hourlyForecasts) { forecast in
+                    HStack {
+                        Text("\(forecast.hour)시")
+                            .frame(width: 50, alignment: .leading)
+                        Spacer()
+                        Text("UV \(forecast.uvIndex.formatted(.number.precision(.fractionLength(1))))")
+                            .foregroundStyle(uvColor(forecast.uvIndex))
+                        Text("\(forecast.temperature.formatted(.number.precision(.fractionLength(0))))°C")
+                            .foregroundStyle(.secondary)
+                            .frame(width: 50, alignment: .trailing)
+                    }
+                }
+            }
+        }
+    }
+    
+    var historySection: some View {
+        Section("과거 UV 조회") {
+            DatePicker("날짜", selection: $viewModel.historyDate, displayedComponents: [.date, .hourAndMinute])
+            
+            Button("과거 UV 조회") {
+                Task { await viewModel.fetchHistoricalUV() }
+            }
+            
+            if let uv = viewModel.historicalUVIndex {
+                row(title: "해당 시점 UV 지수", value: uv.formatted(.number.precision(.fractionLength(1))), color: uvColor(uv))
+            }
+        }
+    }
+    
+    @ViewBuilder
+    var errorSection: some View {
+        if let errorMessage = viewModel.errorMessage {
+            Section("에러") {
+                Text(errorMessage)
+                    .foregroundStyle(.red)
+            }
+        }
+    }
+}
+
+// MARK: - Components
+
+private extension WeatherTestView {
+    
+    func row(title: String, value: String, color: Color = .secondary) -> some View {
+        HStack {
+            Text(title)
+            Spacer()
+            Text(value)
+                .foregroundStyle(color)
+                .bold(color != .secondary)
+        }
+    }
+    
+    func uvColor(_ uv: Double) -> Color {
+        switch uv {
+        case ..<3: .green
+        case 3..<6: .yellow
+        case 6..<8: .orange
+        case 8..<11: .red
+        default: .purple
+        }
+    }
+}
+
+#Preview {
+    WeatherTestView()
+}

--- a/StopSun/StopSun/Views/Tests/WeatherTestViewModel.swift
+++ b/StopSun/StopSun/Views/Tests/WeatherTestViewModel.swift
@@ -1,0 +1,72 @@
+//
+//  WeatherTestViewModel.swift
+//  StopSun
+//
+//  Created by J on 1/30/26.
+//
+
+import Foundation
+
+@MainActor
+final class WeatherTestViewModel: ObservableObject {
+    
+    // MARK: - Published
+    
+    @Published private(set) var currentUVIndex: Double?
+    @Published private(set) var currentWeather: LocationWeather?
+    @Published private(set) var historicalUVIndex: Double?
+    @Published private(set) var errorMessage: String?
+    @Published private(set) var isLoading = false
+    
+    @Published var historyDate: Date
+    
+    // MARK: - Dependencies
+    
+    private let weatherManager: any WeatherManagerProtocol
+    private let locationManager: any LocationManagerProtocol
+    
+    // MARK: - Init
+    
+    init() {
+        self.weatherManager = DIContainer.shared.weather
+        self.locationManager = DIContainer.preview.location
+        self.historyDate = Calendar.current.date(byAdding: .day, value: -1, to: .now) ?? .now
+    }
+
+    // MARK: - Methods
+     
+    func fetchCurrentUVIndex() async {
+        await performTask {
+            let location = try await self.locationManager.getCurrentLocation()
+            self.currentUVIndex = try await self.weatherManager.fetchCurrentUVIndex(for: location)
+        }
+    }
+    
+    func fetchCurrentWeather() async {
+        await performTask {
+            let location = try await self.locationManager.getCurrentLocation()
+            self.currentWeather = try await self.weatherManager.fetchCurrentWeather(for: location)
+        }
+    }
+    
+    func fetchHistoricalUV() async {
+        await performTask {
+            let location = try await self.locationManager.getCurrentLocation()
+            self.historicalUVIndex = try await self.weatherManager.fetchUVIndex(for: location, at: self.historyDate)
+        }
+    }
+    
+    // MARK: - Private
+    
+    private func performTask(_ task: () async throws -> Void) async {
+        errorMessage = nil
+        isLoading = true
+        defer { isLoading = false }
+        
+        do {
+            try await task()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}


### PR DESCRIPTION
## ✨ What’s this PR?

close #15

### 🧶 주요 변경 내용
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- WeatherAPIClient 분리: API 호출 로직 캡슐화
- WeatherManager: 비즈니스 로직만 담당
- 3개 API 엔드포인트 지원
  - `/current.json` - 현재 UV만 (가벼운 호출)
  - `/forecast.json` - 현재 날씨 + 시간별 예보
  - `/history.json` - 과거 UV 조회
- Date+Extensions로 DateFormatter 한 곳에 통합
- WeatherTestView/ViewModel 추가 (테스트용)

---

### 📸 스크린샷 

https://github.com/user-attachments/assets/841a14d2-465a-45b5-8906-62115d560fc3

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] 현재 UV 조회 정상 동작
- [x] 현재 날씨 + 예보 조회 정상 동작
- [x] 과거 UV 조회 정상 동작
- [x] Mock 위치(포항)로 테스트 확인

---

### 💬 기타 공유 사항

**구조:**
```
Managers/
├── WeatherManager.swift          ← 비즈니스 로직
├── Network/
│   ├── WeatherAPI.swift          ← Moya 엔드포인트
│   ├── WeatherAPIClient.swift    ← API 호출 담당
│   └── WeatherAPIResponse.swift  ← 응답 모델
```

**WeatherManager / WeatherAPIClient 분리 이유:**
- 현재 API 하나뿐이라 오버엔지니어링일 수 있지만, 나중에 다른 날씨 API로 교체할 가능성 고려
- API 변경 시 WeatherAPIClient만 수정하면 WeatherManager는 그대로 유지 가능

**API Key**
키를 숨기기위해서 xcconfig, info.plist 방식을 사용했는데 키값 자체는 저희 톡방으로 드리도록 하겠습니다!

**의존성:**
- Moya 패키지 추가 필요 (SPM)
