### PR TITLE
✨ Feature: #21 SEDCalculator 구현

### DIFF
--- a/StopSun/StopSun.xcodeproj/project.pbxproj
+++ b/StopSun/StopSun.xcodeproj/project.pbxproj
@@ -18,6 +18,13 @@
 			remoteGlobalIDString = 058BD6812E793E3A00AAF08B;
 			remoteInfo = "StopSunWatch Watch App";
 		};
+		804E4BE32F309FE40019E4EE /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 058BD6682E793E2C00AAF08B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 058BD66F2E793E2C00AAF08B;
+			remoteInfo = StopSun;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -37,6 +44,7 @@
 /* Begin PBXFileReference section */
 		058BD6702E793E2C00AAF08B /* StopSun.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = StopSun.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		058BD6822E793E3A00AAF08B /* StopSunWatch Watch App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "StopSunWatch Watch App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		804E4BDF2F309FE40019E4EE /* StopSunTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = StopSunTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -68,6 +76,11 @@
 			path = Shared;
 			sourceTree = "<group>";
 		};
+		804E4BE02F309FE40019E4EE /* StopSunTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = StopSunTests;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -85,6 +98,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		804E4BDC2F309FE40019E4EE /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -94,6 +114,7 @@
 				058BD6AD2E793EC000AAF08B /* Shared */,
 				058BD6722E793E2C00AAF08B /* StopSun */,
 				058BD6832E793E3A00AAF08B /* StopSunWatch Watch App */,
+				804E4BE02F309FE40019E4EE /* StopSunTests */,
 				058BD6712E793E2C00AAF08B /* Products */,
 			);
 			sourceTree = "<group>";
@@ -103,6 +124,7 @@
 			children = (
 				058BD6702E793E2C00AAF08B /* StopSun.app */,
 				058BD6822E793E3A00AAF08B /* StopSunWatch Watch App.app */,
+				804E4BDF2F309FE40019E4EE /* StopSunTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -157,6 +179,29 @@
 			productReference = 058BD6822E793E3A00AAF08B /* StopSunWatch Watch App.app */;
 			productType = "com.apple.product-type.application";
 		};
+		804E4BDE2F309FE40019E4EE /* StopSunTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 804E4BE52F309FE40019E4EE /* Build configuration list for PBXNativeTarget "StopSunTests" */;
+			buildPhases = (
+				804E4BDB2F309FE40019E4EE /* Sources */,
+				804E4BDC2F309FE40019E4EE /* Frameworks */,
+				804E4BDD2F309FE40019E4EE /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				804E4BE42F309FE40019E4EE /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				804E4BE02F309FE40019E4EE /* StopSunTests */,
+			);
+			name = StopSunTests;
+			packageProductDependencies = (
+			);
+			productName = StopSunTests;
+			productReference = 804E4BDF2F309FE40019E4EE /* StopSunTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -172,6 +217,10 @@
 					};
 					058BD6812E793E3A00AAF08B = {
 						CreatedOnToolsVersion = 16.4;
+					};
+					804E4BDE2F309FE40019E4EE = {
+						CreatedOnToolsVersion = 16.4;
+						TestTargetID = 058BD66F2E793E2C00AAF08B;
 					};
 				};
 			};
@@ -191,6 +240,7 @@
 			targets = (
 				058BD66F2E793E2C00AAF08B /* StopSun */,
 				058BD6812E793E3A00AAF08B /* StopSunWatch Watch App */,
+				804E4BDE2F309FE40019E4EE /* StopSunTests */,
 			);
 		};
 /* End PBXProject section */
@@ -204,6 +254,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		058BD6802E793E3A00AAF08B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		804E4BDD2F309FE40019E4EE /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -227,6 +284,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		804E4BDB2F309FE40019E4EE /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -234,6 +298,11 @@
 			isa = PBXTargetDependency;
 			target = 058BD6812E793E3A00AAF08B /* StopSunWatch Watch App */;
 			targetProxy = 058BD68A2E793E3B00AAF08B /* PBXContainerItemProxy */;
+		};
+		804E4BE42F309FE40019E4EE /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 058BD66F2E793E2C00AAF08B /* StopSun */;
+			targetProxy = 804E4BE32F309FE40019E4EE /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -501,6 +570,40 @@
 			};
 			name = Release;
 		};
+		804E4BE62F309FE40019E4EE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.xcodeblue.StopSunTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/StopSun.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/StopSun";
+			};
+			name = Debug;
+		};
+		804E4BE72F309FE40019E4EE /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.xcodeblue.StopSunTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/StopSun.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/StopSun";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -527,6 +630,15 @@
 			buildConfigurations = (
 				058BD68E2E793E3B00AAF08B /* Debug */,
 				058BD68F2E793E3B00AAF08B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		804E4BE52F309FE40019E4EE /* Build configuration list for PBXNativeTarget "StopSunTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				804E4BE62F309FE40019E4EE /* Debug */,
+				804E4BE72F309FE40019E4EE /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/StopSun/StopSun/Utilities/SEDCalculator.swift
+++ b/StopSun/StopSun/Utilities/SEDCalculator.swift
@@ -1,0 +1,282 @@
+//
+//  SEDCalculator.swift
+//  StopSun
+//
+//  Created by J on 2/2/26.
+//
+
+import Foundation
+
+/// 자외선 노출량(SED) 계산기
+///
+/// SED (Standard Erythema Dose)는 피부 홍반을 유발하는 표준 자외선 노출 단위입니다.
+///
+/// ## Overview
+///
+/// SED는 MED(Minimal Erythema Dose)와 달리 **절대적인 단위**입니다.
+/// - MED: 개인마다 다름 (피부 타입별로 홍반이 생기는 최소량)
+/// - SED: 누구에게나 동일 (1 SED = 100 J/m²)
+///
+/// ## 계산 공식
+///
+/// ```
+/// 1. UV Dose (J/m²) = UV Index × 0.025 (W/m²) × 노출 시간 (초)
+/// 2. SED = UV Dose ÷ 100
+/// 3. 실제 SED = SED ÷ SPF (선크림 적용 시)
+/// ```
+///
+/// ## 사용 예시
+///
+/// ```swift
+/// // UV Index 8, 30분 노출, SPF 30
+/// let sed = SEDCalculator.calculate(uvIndex: 8, durationMinutes: 30, spf: 30)
+/// // → 0.12 SED
+///
+/// // 진행률 계산
+/// let progress = SEDCalculator.progress(currentSED: 2.0, skinType: .type3)
+/// // → 0.5 (50%)
+/// ```
+///
+/// ## Topics
+///
+/// ### 계산
+/// - ``calculate(uvIndex:durationMinutes:spf:)``
+/// - ``calculateDose(uvIndex:durationMinutes:)``
+///
+/// ### 피부 타입별 기준
+/// - ``maxSED(for:)``
+/// - ``progress(currentSED:skinType:)``
+///
+/// ### 상수
+/// - ``uvIndexToIrradiance``
+/// - ``joulesPerSED``
+///
+struct SEDCalculator {
+    
+    // MARK: - Initializer
+    
+    /// 인스턴스화 방지
+    private init() {}
+    
+    // MARK: - Constants
+    
+    /// UV Index를 Irradiance(W/m²)로 변환하는 계수
+    ///
+    /// WHO 정의에 따라 UV Index 1 = 0.025 W/m² (erythemal effective UV)
+    ///
+    /// ```swift
+    /// let irradiance = uvIndex * SEDCalculator.uvIndexToIrradiance
+    /// // UV Index 10 → 0.25 W/m²
+    /// ```
+    static let uvIndexToIrradiance: Double = 0.025
+    
+    /// 1 SED에 해당하는 에너지량 (J/m²)
+    ///
+    /// CIE(국제조명위원회) 정의에 따라 1 SED = 100 J/m²
+    ///
+    /// ```swift
+    /// let sed = uvDose / SEDCalculator.joulesPerSED
+    /// // 300 J/m² → 3.0 SED
+    /// ```
+    static let joulesPerSED: Double = 100.0
+    
+    // MARK: - Calculation Methods
+    
+    /// UV Dose(J/m²) 계산
+    ///
+    /// UV Index와 노출 시간으로 총 자외선 노출량을 계산합니다.
+    /// SPF를 적용하지 않은 순수 노출량입니다.
+    ///
+    /// - Parameters:
+    ///   - uvIndex: 자외선 지수 (0~11+)
+    ///   - durationMinutes: 노출 시간 (분)
+    ///
+    /// - Returns: UV Dose (J/m²)
+    ///
+    /// ## 계산 공식
+    /// ```
+    /// UV Dose = UV Index × 0.025 (W/m²) × 노출 시간 (초)
+    /// ```
+    ///
+    /// ## 예시
+    /// ```swift
+    /// let dose = SEDCalculator.calculateDose(uvIndex: 8, durationMinutes: 30)
+    /// // 8 × 0.025 × 1800 = 360 J/m²
+    /// ```
+    static func calculateDose(uvIndex: Double, durationMinutes: Double) -> Double {
+        let durationSeconds = durationMinutes * 60.0
+        let irradiance = uvIndex * uvIndexToIrradiance
+        return irradiance * durationSeconds
+    }
+    
+    /// SED 계산
+    ///
+    /// UV Index, 노출 시간, SPF를 고려하여 실제 SED를 계산합니다.
+    ///
+    /// - Parameters:
+    ///   - uvIndex: 자외선 지수 (0~11+)
+    ///   - durationMinutes: 노출 시간 (분)
+    ///   - spf: 선크림 SPF 값 (nil이면 선크림 미적용)
+    ///
+    /// - Returns: 계산된 SED 값
+    ///
+    /// ## 계산 공식
+    /// ```
+    /// 1. UV Dose (J/m²) = UV Index × 0.025 × 노출 시간 (초)
+    /// 2. SED = UV Dose ÷ 100
+    /// 3. 실제 SED = SED ÷ SPF (선크림 적용 시)
+    /// ```
+    ///
+    /// ## 예시
+    /// ```swift
+    /// // 선크림 없이
+    /// let sed1 = SEDCalculator.calculate(uvIndex: 8, durationMinutes: 30)
+    /// // → 3.6 SED
+    ///
+    /// // SPF 30 적용
+    /// let sed2 = SEDCalculator.calculate(uvIndex: 8, durationMinutes: 30, spf: 30)
+    /// // → 0.12 SED
+    /// ```
+    static func calculate(
+        uvIndex: Double,
+        durationMinutes: Double,
+        spf: Double? = nil
+    ) -> Double {
+        let dose = calculateDose(uvIndex: uvIndex, durationMinutes: durationMinutes)
+        var sed = dose / joulesPerSED
+        
+        if let spfValue = spf, spfValue >= 1 {
+            sed /= spfValue
+        }
+        
+        return sed
+    }
+    
+    // MARK: - Skin Type Methods
+    
+    /// 피부 타입별 일일 권장 최대 SED
+    ///
+    /// Fitzpatrick 피부 타입 분류에 따른 일일 권장 최대 자외선 노출량입니다.
+    /// 이 값을 초과하면 피부 손상 위험이 있습니다.
+    ///
+    /// - Parameter skinType: 피부 타입
+    /// - Returns: 일일 권장 최대 SED
+    ///
+    /// ## 피부 타입별 최대 SED
+    ///
+    /// | 타입 | 설명 | 최대 SED |
+    /// |-----|------|---------|
+    /// | I | 매우 하얀 피부, 항상 화상 | 1.5 |
+    /// | II | 하얀 피부, 쉽게 화상 | 3.0 |
+    /// | III | 약간 어두운 피부 | 4.0 |
+    /// | IV | 올리브톤/황갈색 피부 | 5.0 |
+    /// | V | 갈색 피부 | 7.0 |
+    /// | VI | 매우 어두운 피부 | 12.0 |
+    ///
+    /// ## 예시
+    /// ```swift
+    /// let maxSED = SEDCalculator.maxSED(for: .type3)
+    /// // → 4.0
+    /// ```
+    static func maxSED(for skinType: SkinType) -> Double {
+        switch skinType {
+        case .type1: 1.5
+        case .type2: 3.0
+        case .type3: 4.0
+        case .type4: 5.0
+        case .type5: 7.0
+        case .type6: 12.0
+        }
+    }
+    
+    /// SED 진행률 계산
+    ///
+    /// 현재 SED가 피부 타입별 최대 SED 대비 몇 %인지 계산합니다.
+    /// 1.0(100%)을 초과할 수 있습니다.
+    ///
+    /// - Parameters:
+    ///   - currentSED: 현재까지 누적된 SED
+    ///   - skinType: 피부 타입
+    ///
+    /// - Returns: 진행률 (0.0 ~ 1.0+)
+    ///
+    /// ## 예시
+    /// ```swift
+    /// // Type III (최대 4.0 SED)에서 2.0 SED 받음
+    /// let progress = SEDCalculator.progress(currentSED: 2.0, skinType: .type3)
+    /// // → 0.5 (50%)
+    ///
+    /// // 초과한 경우
+    /// let overProgress = SEDCalculator.progress(currentSED: 5.0, skinType: .type3)
+    /// // → 1.25 (125%)
+    /// ```
+    static func progress(currentSED: Double, skinType: SkinType) -> Double {
+        let max = maxSED(for: skinType)
+        guard max > 0 else { return 0 }
+        return currentSED / max
+    }
+    
+    /// 남은 SED 계산
+    ///
+    /// 일일 권장량까지 남은 SED를 계산합니다.
+    /// 이미 초과한 경우 0을 반환합니다.
+    ///
+    /// - Parameters:
+    ///   - currentSED: 현재까지 누적된 SED
+    ///   - skinType: 피부 타입
+    ///
+    /// - Returns: 남은 SED (최소 0)
+    ///
+    /// ## 예시
+    /// ```swift
+    /// let remaining = SEDCalculator.remainingSED(currentSED: 2.0, skinType: .type3)
+    /// // → 2.0 (4.0 - 2.0)
+    /// ```
+    static func remainingSED(currentSED: Double, skinType: SkinType) -> Double {
+        let max = maxSED(for: skinType)
+        return Swift.max(0, max - currentSED)
+    }
+    
+    /// 권장량 초과까지 남은 시간 계산
+    ///
+    /// 현재 UV Index에서 권장량 초과까지 남은 시간을 계산합니다.
+    ///
+    /// - Parameters:
+    ///   - currentSED: 현재까지 누적된 SED
+    ///   - skinType: 피부 타입
+    ///   - uvIndex: 현재 UV Index
+    ///   - spf: 선크림 SPF 값 (nil이면 미적용)
+    ///
+    /// - Returns: 남은 시간 (분), 이미 초과했으면 0
+    ///
+    /// ## 예시
+    /// ```swift
+    /// // Type III, 현재 2.0 SED, UV Index 8, SPF 없음
+    /// let minutes = SEDCalculator.minutesUntilMax(
+    ///     currentSED: 2.0,
+    ///     skinType: .type3,
+    ///     uvIndex: 8
+    /// )
+    /// // 남은 2.0 SED를 채우는 데 필요한 시간
+    /// ```
+    static func minutesUntilMax(
+        currentSED: Double,
+        skinType: SkinType,
+        uvIndex: Double,
+        spf: Double? = nil
+    ) -> Double {
+        let remaining = remainingSED(currentSED: currentSED, skinType: skinType)
+        guard remaining > 0, uvIndex > 0 else { return 0 }
+        
+        // 1분당 SED 계산
+        var sedPerMinute = calculate(uvIndex: uvIndex, durationMinutes: 1, spf: nil)
+        
+        if let spfValue = spf, spfValue >= 1 {
+            sedPerMinute /= spfValue
+        }
+        
+        guard sedPerMinute > 0 else { return 0 }
+        
+        return remaining / sedPerMinute
+    }
+}

--- a/StopSun/StopSunTests/SEDCalculatorTests.swift
+++ b/StopSun/StopSunTests/SEDCalculatorTests.swift
@@ -1,0 +1,172 @@
+//
+//  SEDCalculatorTests.swift
+//  StopSunTests
+//
+//  Created by J on 2/2/26.
+//
+
+import XCTest
+@testable import StopSun
+
+final class SEDCalculatorTests: XCTestCase {
+    
+    // MARK: - Constants Tests
+    
+    func test_constants() {
+        XCTAssertEqual(SEDCalculator.uvIndexToIrradiance, 0.025)
+        XCTAssertEqual(SEDCalculator.joulesPerSED, 100.0)
+    }
+    
+    // MARK: - calculateDose Tests
+    
+    func test_calculateDose_basic() {
+        // UV Index 8, 30분
+        // 8 * 0.025 * 1800 = 360 J/m²
+        let dose = SEDCalculator.calculateDose(uvIndex: 8, durationMinutes: 30)
+        XCTAssertEqual(dose, 360.0, accuracy: 0.01)
+    }
+    
+    func test_calculateDose_zeroUV() {
+        let dose = SEDCalculator.calculateDose(uvIndex: 0, durationMinutes: 30)
+        XCTAssertEqual(dose, 0.0)
+    }
+    
+    func test_calculateDose_zeroDuration() {
+        let dose = SEDCalculator.calculateDose(uvIndex: 8, durationMinutes: 0)
+        XCTAssertEqual(dose, 0.0)
+    }
+    
+    // MARK: - calculate (SED) Tests
+      
+      func test_calculate_withoutSPF() {
+          // UV Index 8, 30분, SPF 없음
+          // Dose = 360 J/m² → SED = 3.6
+          let sed = SEDCalculator.calculate(uvIndex: 8, durationMinutes: 30)
+          XCTAssertEqual(sed, 3.6, accuracy: 0.01)
+      }
+      
+      func test_calculate_withSPF() {
+          // UV Index 8, 30분, SPF 30
+          // SED = 3.6 ÷ 30 = 0.12
+          let sed = SEDCalculator.calculate(uvIndex: 8, durationMinutes: 30, spf: 30)
+          XCTAssertEqual(sed, 0.12, accuracy: 0.001)
+      }
+      
+      func test_calculate_withSPF1() {
+          // SPF 1은 효과 없음
+          let sedNoSPF = SEDCalculator.calculate(uvIndex: 8, durationMinutes: 30, spf: nil)
+          let sedSPF1 = SEDCalculator.calculate(uvIndex: 8, durationMinutes: 30, spf: 1)
+          XCTAssertEqual(sedNoSPF, sedSPF1, accuracy: 0.01)
+      }
+      
+      func test_calculate_withInvalidSPF() {
+          // SPF 0 이하는 무시
+          let sedNoSPF = SEDCalculator.calculate(uvIndex: 8, durationMinutes: 30, spf: nil)
+          let sedSPF0 = SEDCalculator.calculate(uvIndex: 8, durationMinutes: 30, spf: 0)
+          XCTAssertEqual(sedNoSPF, sedSPF0, accuracy: 0.01)
+      }
+    
+    // MARK: - maxSED Tests
+    
+    func test_maxSED_allTypes() {
+        XCTAssertEqual(SEDCalculator.maxSED(for: .type1), 1.5)
+        XCTAssertEqual(SEDCalculator.maxSED(for: .type2), 3.0)
+        XCTAssertEqual(SEDCalculator.maxSED(for: .type3), 4.0)
+        XCTAssertEqual(SEDCalculator.maxSED(for: .type4), 5.0)
+        XCTAssertEqual(SEDCalculator.maxSED(for: .type5), 7.0)
+        XCTAssertEqual(SEDCalculator.maxSED(for: .type6), 12.0)
+    }
+    
+    // MARK: - progress Tests
+    
+    func test_progress_half() {
+        // Type III (max 4.0), 현재 2.0 → 50%
+        let progress = SEDCalculator.progress(currentSED: 2.0, skinType: .type3)
+        XCTAssertEqual(progress, 0.5, accuracy: 0.01)
+    }
+    
+    func test_progress_full() {
+        // Type III (max 4.0), 현재 4.0 → 100%
+        let progress = SEDCalculator.progress(currentSED: 4.0, skinType: .type3)
+        XCTAssertEqual(progress, 1.0, accuracy: 0.01)
+    }
+    
+    func test_progress_over() {
+        // Type III (max 4.0), 현재 5.0 → 125%
+        let progress = SEDCalculator.progress(currentSED: 5.0, skinType: .type3)
+        XCTAssertEqual(progress, 1.25, accuracy: 0.01)
+    }
+    
+    func test_progress_zero() {
+        let progress = SEDCalculator.progress(currentSED: 0, skinType: .type3)
+        XCTAssertEqual(progress, 0.0)
+    }
+    
+    // MARK: - remainingSED Tests
+    
+    func test_remainingSED_normal() {
+        // Type III (max 4.0), 현재 2.0 → 남은 2.0
+        let remaining = SEDCalculator.remainingSED(currentSED: 2.0, skinType: .type3)
+        XCTAssertEqual(remaining, 2.0, accuracy: 0.01)
+    }
+    
+    func test_remainingSED_over() {
+        // 이미 초과했으면 0
+        let remaining = SEDCalculator.remainingSED(currentSED: 5.0, skinType: .type3)
+        XCTAssertEqual(remaining, 0.0)
+    }
+    
+    // MARK: - minutesUntilMax Tests
+    
+    func test_minutesUntilMax_normal() {
+        // Type III (max 4.0), 현재 2.0, UV Index 8
+        // 남은 2.0 SED, 분당 SED = 0.12
+        // 2.0 / 0.12 = 16.67분
+        let minutes = SEDCalculator.minutesUntilMax(
+            currentSED: 2.0,
+            skinType: .type3,
+            uvIndex: 8,
+            spf: nil
+        )
+        XCTAssertEqual(minutes, 16.67, accuracy: 0.1)
+    }
+    
+    func test_minutesUntilMax_withSPF() {
+        // SPF 30 적용하면 30배 더 오래 걸림
+        let minutesNoSPF = SEDCalculator.minutesUntilMax(
+            currentSED: 2.0,
+            skinType: .type3,
+            uvIndex: 8,
+            spf: nil
+        )
+        let minutesWithSPF = SEDCalculator.minutesUntilMax(
+            currentSED: 2.0,
+            skinType: .type3,
+            uvIndex: 8,
+            spf: 30
+        )
+        XCTAssertEqual(minutesWithSPF, minutesNoSPF * 30, accuracy: 0.1)
+    }
+    
+    func test_minutesUntilMax_alreadyOver() {
+        // 이미 초과했으면 0
+        let minutes = SEDCalculator.minutesUntilMax(
+            currentSED: 5.0,
+            skinType: .type3,
+            uvIndex: 8,
+            spf: nil
+        )
+        XCTAssertEqual(minutes, 0.0)
+    }
+    
+    func test_minutesUntilMax_zeroUV() {
+        // UV Index 0이면 0
+        let minutes = SEDCalculator.minutesUntilMax(
+            currentSED: 2.0,
+            skinType: .type3,
+            uvIndex: 0,
+            spf: nil
+        )
+        XCTAssertEqual(minutes, 0.0)
+    }
+}

--- a/StopSun/StopSunTests/StopSunTests.swift
+++ b/StopSun/StopSunTests/StopSunTests.swift
@@ -1,0 +1,16 @@
+//
+//  StopSunTests.swift
+//  StopSunTests
+//
+//  Created by J on 2/2/26.
+//
+
+import Testing
+
+struct StopSunTests {
+
+    @Test func example() async throws {
+        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    }
+
+}


### PR DESCRIPTION
## ✨ What's this PR?
close #21 

### 🧶 주요 변경 내용
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- `SEDCalculator` 정적 struct 구현
- UV Dose 계산 (UV Index × 0.025 × 시간)
- SED 계산 (UV Dose ÷ 100, SPF 적용)
- 피부 타입별 일일 권장 최대 SED
- 진행률 / 남은 SED / 권장량 초과까지 남은 시간 계산
- Unit Test 19개 추가
- DocC 문서화

---

### 🧪 테스트 / 검증 내역

**Unit Test 참고**

- [x] `test_calculateDose_*` - UV Dose 계산 (3개)
- [x] `test_calculate_*` - SED 계산, SPF 적용 (4개)
- [x] `test_maxSED_allTypes` - 피부 타입별 최대 SED
- [x] `test_progress_*` - 진행률 계산 (4개)
- [x] `test_remainingSED_*` - 남은 SED (2개)
- [x] `test_minutesUntilMax_*` - 권장량 초과까지 시간 (4개)

---

### 💬 기타 공유 사항

**SED란?**
- Standard Erythema Dose (표준 홍반 선량)
- 1 SED = 100 J/m²
- 내부 계산용 절대 단위, UI에서는 진행률(%)로 표시 예정