### PR TITLE
🐛 Bug: #53 LocationManager 타임아웃

### DIFF
--- a/StopSun/StopSun/Managers/LocationManager.swift
+++ b/StopSun/StopSun/Managers/LocationManager.swift
@@ -34,6 +34,9 @@ final class LocationManager: NSObject, LocationManagerProtocol {
      
      /// 권한 요청 continuation
      private var authContinuation: CheckedContinuation<Void, Never>?
+     
+     /// 타임아웃 Task (정상 응답 시 취소)
+     private var timeoutTask: Task<Void, Never>?
     
     // MARK: - Init
     
@@ -139,13 +142,14 @@ final class LocationManager: NSObject, LocationManagerProtocol {
             existing.resume(throwing: CancellationError())
             locationContinuation = nil
         }
+        timeoutTask?.cancel()
         
         return try await withCheckedThrowingContinuation { continuation in
             locationContinuation = continuation
             clLocationManager.requestLocation()
             
             // 타임아웃: 응답 없으면 에러 반환
-            Task { [weak self] in
+            timeoutTask = Task { [weak self] in
                 try? await Task.sleep(nanoseconds: 10 * 1_000_000_000)
                 
                 guard let self, let pending = self.locationContinuation else { return }
@@ -199,6 +203,8 @@ extension LocationManager: CLLocationManagerDelegate {
         
         // 단일 위치 요청 응답
         if let continuation = locationContinuation {
+            timeoutTask?.cancel()
+            timeoutTask = nil
             locationContinuation = nil
             continuation.resume(returning: location)
             return
@@ -212,6 +218,8 @@ extension LocationManager: CLLocationManagerDelegate {
         Log.error("위치 조회 실패: \(error.localizedDescription)")
         
         if let continuation = locationContinuation {
+            timeoutTask?.cancel()
+            timeoutTask = nil
             locationContinuation = nil
             continuation.resume(throwing: AppError.location(.locationUnavailable))
         }


### PR DESCRIPTION
- close #53 

## ✨ What’s this PR?

### 🧶 주요 변경 내용

- timeoutTask 프로퍼티 추가 — 타임아웃 Task를 저장하여 추후 취소 가능하게 변경

기존 코드에서 10초 타임아웃 Task가 정상 응답이 와도 타임아웃 Task가 취소되지 않았습니다! 정상 응답과 타임아웃이 거의 동시에 실행되면 CheckedContinuation이 2번 resume되어 런타임 크래시가 발생할 수 있습니다.

```swift
// Before — 타임아웃 Task 저장 안 함
Task { [weak self] in
    try? await Task.sleep(nanoseconds: 10_000_000_000)
    pending.resume(throwing: ...)  // resume A
}
// delegate에서도 resume
continuation.resume(returning: location)   // resume B → 동시 실행 시 크래시

// After — 정상 응답 시 타임아웃 취소
timeoutTask = Task { [weak self] in ... }
// delegate에서
timeoutTask?.cancel()
continuation.resume(returning: location)   // resume 1번만
```
---

### 📸 스크린샷 

UI 변경 없음

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] iPhone 16, iOS 26.0 환경에서 정상 동작
- [ ] 다크모드 테스트는 이후 이슈로 분리 예정 (#000)

---

### 💬 기타 공유 사항

(없음)