### PR TITLE
🐛 Bug: #59 refresh()에서 UserProfile 미로드 수정

### DIFF
--- a/StopSun/StopSun/Application/StopSunApp.swift
+++ b/StopSun/StopSun/Application/StopSunApp.swift
@@ -33,7 +33,6 @@ struct StopSunApp: App {
         case .active:
             Task {
                 await container.permissionManager.checkAllStatuses()
-                await container.syncCoordinator.refresh()
             }
         case .background:
             container.syncCoordinator.handleAppWillResignActive()

--- a/StopSun/StopSun/Managers/SyncCoordinator.swift
+++ b/StopSun/StopSun/Managers/SyncCoordinator.swift
@@ -250,9 +250,10 @@ final class SyncCoordinator: SyncCoordinatorProtocol {
         // 2. 저장된 선크림 상태 로드
         loadActiveSunscreen()
 
-        // 4. 위치 권한 요청 및 현재 위치 가져오기
+        // 3. 위치 권한 요청 및 현재 위치 가져오기
         await location.requestAuthorization()
-        // 3. HealthKit Background Delivery 설정 (권한은 온보딩에서 요청 완료)
+        
+        // 4. HealthKit Background Delivery 설정 (권한은 온보딩에서 요청 완료)
         if healthKit.isAuthorized {
             do {
                 try await healthKit.enableBackgroundDelivery()
@@ -264,7 +265,7 @@ final class SyncCoordinator: SyncCoordinatorProtocol {
             Log.warning("HealthKit 권한 없음 — Background Delivery 스킵")
         }
         
-        // 4. 현재 위치 및 날씨 조회 (권한은 온보딩에서 요청 완료)
+        // 5. 현재 위치 및 날씨 조회 (권한은 온보딩에서 요청 완료)
         if location.isAuthorized {
             location.startMonitoringSignificantLocationChanges()
             await fetchCurrentLocationAndWeather()
@@ -272,18 +273,18 @@ final class SyncCoordinator: SyncCoordinatorProtocol {
             Log.warning("위치 권한 없음 — 위치/날씨 조회 스킵")
         }
         
-        // 5. 알림 — 권한 없어도 동기화에 영향 없음
+        // 6. 알림 — 권한 없어도 동기화에 영향 없음
         if !notification.isAuthorized {
             Log.warning("알림 권한 없음 — 알림 기능 제한")
         }
         
-        // 6. 오늘 SED 계산
+        // 7. 오늘 SED 계산
         await calculateTodaySED()
         
-        // 7. 선크림 만료 체크 및 알림 재예약
+        // 8. 선크림 만료 체크 및 알림 재예약
         checkSunscreenAndScheduleReminder()
 
-        // 7-1. 활성 선크림이 있고, 시간이 남았으며, Live Activity가 없으면 복원
+        // 8-1. 활성 선크림이 있고, 시간이 남았으며, Live Activity가 없으면 복원
         // MED 계산 이후이므로 progress에 실제 계산된 값이 반영됨
         if let sunscreen = activeSunscreen,
            sunscreen.nextReapplyTime > .now,
@@ -297,7 +298,7 @@ final class SyncCoordinator: SyncCoordinatorProtocol {
             )
         }
 
-        // 8. 경고 레벨 체크 (Live Activity 초기 warningLevel 갱신 포함)
+        // 9. 경고 레벨 체크 (Live Activity 초기 warningLevel 갱신 포함)
         checkWarningLevelAndNotify()
 
         Log.info("동기화 완료")
@@ -316,8 +317,6 @@ final class SyncCoordinator: SyncCoordinatorProtocol {
         }
         
         Log.info("새로고침 시작")
-        
-        loadUserProfile()
         
         // 1. 현재 위치 및 날씨 조회
         await fetchCurrentLocationAndWeather()

--- a/StopSun/StopSun/Managers/SyncCoordinator.swift
+++ b/StopSun/StopSun/Managers/SyncCoordinator.swift
@@ -317,6 +317,8 @@ final class SyncCoordinator: SyncCoordinatorProtocol {
         
         Log.info("새로고침 시작")
         
+        loadUserProfile()
+        
         // 1. 현재 위치 및 날씨 조회
         await fetchCurrentLocationAndWeather()
         

--- a/StopSun/StopSun/ViewModels/DashboardViewModel.swift
+++ b/StopSun/StopSun/ViewModels/DashboardViewModel.swift
@@ -120,16 +120,21 @@ final class DashboardViewModel {
         // 날짜 갱신 (자정 지났을 때 대비)
         formattedDate = Date().toDayWithWeekdayString
         
-        // 한 번도 sync 안 했으면 바로 시작
+        // 최초 진입: startSync (HealthKit BD, Watch 활성화 등 포함)
         guard let lastSync = syncCoordinator.lastSyncTime else {
             await syncCoordinator.startSync()
             return
         }
         
-        // 마지막 sync로부터 15분 이상 경과했으면 재sync
+        // 15분 이상 경과: 가벼운 refresh만
         if Date().timeIntervalSince(lastSync) > resyncInterval {
-            await syncCoordinator.startSync()
+            await syncCoordinator.refresh()  // startSync → refresh
         }
+    }
+    
+    /// Pull-to-refresh
+    func pullToRefresh() async {
+        await syncCoordinator.refresh()
     }
     
     // MARK: - Debug

--- a/StopSun/StopSun/Views/Dashboard/DashboardView.swift
+++ b/StopSun/StopSun/Views/Dashboard/DashboardView.swift
@@ -45,6 +45,9 @@ struct DashboardView: View {
                 .padding(.bottom, 20)
             }
             .scrollIndicators(.hidden)
+            .refreshable {
+                await viewModel.pullToRefresh()
+            }
         }
         .task {
             await viewModel.onAppear()


### PR DESCRIPTION
## ✨ What’s this PR?

- close #59 

### 🧶 주요 변경 내용

- SyncCoordinator.refresh()에 loadUserProfile() 호출 추가
- refresh() 경로에서도 userProfile이 정상 로드되어 MED 진행률 및 최대 허용량이 올바르게 표시됨

---

### 📸 스크린샷 

<img width=300 src="https://github.com/user-attachments/assets/d26c933e-4b4e-4e31-adc8-534b503c716a"/>

날짜가 넘어가서 안뜨는 겁니다!  (최대 UV 노출량 잘 뜸!)

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] 앱 최초 실행 → 대시보드 진입 → MED 최대값 및 진행률 정상 표시
- [x] 백그라운드 → 포그라운드 복귀 시 refresh() 경로에서도 프로필 유지 확인
- [x] 온보딩 미완료 상태에서 .defaultUser 폴백 정상 동작 확인

---

### 💬 기타 공유 사항

디버깅 창은 release 로 빌드 하면 안 뜹니다!