### PR TITLE
♻️ Refactor: #69 Dashboard 뷰 QA

### DIFF
--- a/StopSun/Shared/Resources/Models/Response/WeeklyBarItem.swift
+++ b/StopSun/Shared/Resources/Models/Response/WeeklyBarItem.swift
@@ -12,14 +12,10 @@ import Foundation
 /// - `percent`: `nil`이면 데이터 없음, `0`이면 노출 없음
 /// - `isToday`: 오늘 날짜 강조 여부
 struct WeeklyBarItem: Identifiable, Equatable {
-    let id = UUID()
     let dayLabel: String
-    let percent: Double?
+    let percent: Double
+    let exposureMinutes: Int
     let isToday: Bool
     
-    static func == (lhs: Self, rhs: Self) -> Bool {
-        lhs.dayLabel == rhs.dayLabel
-        && lhs.percent == rhs.percent
-        && lhs.isToday == rhs.isToday
-    }
+    var id: String { dayLabel }
 }

--- a/StopSun/Shared/Resources/Models/Stored/DailyMEDRecord.swift
+++ b/StopSun/Shared/Resources/Models/Stored/DailyMEDRecord.swift
@@ -42,16 +42,21 @@ struct DailyMEDRecord: Codable, Identifiable {
     /// 노출 횟수
     var recordCount: Int
     
+    /// 노출 시간 (분)
+    var totalExposureMinutes: Int
+    
     init(
         id: UUID = UUID(),
         date: Date,
         totalSED: Double = 0,
-        recordCount: Int = 0
+        recordCount: Int = 0,
+        totalExposureMinutes: Int = 0
     ) {
         self.id = id
         self.date = date
         self.totalSED = totalSED
         self.recordCount = recordCount
+        self.totalExposureMinutes = totalExposureMinutes
     }
     
     /// 새 노출 추가

--- a/StopSun/StopSun/Application/Route.swift
+++ b/StopSun/StopSun/Application/Route.swift
@@ -19,6 +19,6 @@ import Foundation
 /// ```
 ///
 enum Route: Hashable {
-    // TODO: 탭 내부 push 화면 추가 시 여기에 정의
+    // MARK: 탭 내부 push 화면 추가 시 여기에 정의
     case skinTypeSettings
 }

--- a/StopSun/StopSun/Managers/HealthKitManager.swift
+++ b/StopSun/StopSun/Managers/HealthKitManager.swift
@@ -31,7 +31,6 @@ final class HealthKitManager: HealthKitManagerProtocol {
     // MARK: - Authorization
     
     func requestAuthorization() async throws {
-        // TODO: 구현
         guard isAvailable else {
             throw AppError.healthKit(.notAvailable)
         }
@@ -44,7 +43,6 @@ final class HealthKitManager: HealthKitManagerProtocol {
     // MARK: - Fetch Data
     
     func fetchTodayTimeInDaylight() async throws -> [TimeInDaylight] {
-        // TODO: 구현
         let calendar = Calendar.current
         let startOfDay = calendar.startOfDay(for: Date())
         let now = Date()
@@ -112,7 +110,6 @@ final class HealthKitManager: HealthKitManagerProtocol {
             
             guard error == nil else { return }
             
-            // TODO: - NotificationCenter 파일 분리 필요
             NotificationCenter.default.post(name: .healthKitDataDidUpdate, object: nil)
         }
         

--- a/StopSun/StopSun/Managers/SyncCoordinator.swift
+++ b/StopSun/StopSun/Managers/SyncCoordinator.swift
@@ -394,12 +394,17 @@ private extension SyncCoordinator {
             
             todayTotalSED = runningTotal
             
+            let totalMinutes = timeInDaylightData.reduce(0) { total, data in
+                total + Int(data.endTime.timeIntervalSince(data.startTime) / 60)
+            }
+            
             Log.debug("새로 처리: \(newCount)건, 최종 SED: \(String(format: "%.4f", todayTotalSED))")
             
             // 일일 MED 기록 업데이트
             var dailyRecord = localStorage.loadDailyMEDRecord(for: Date()) ?? DailyMEDRecord(date: Date())
             dailyRecord.totalSED = todayTotalSED
             dailyRecord.recordCount = existingRecords.count + newCount
+            dailyRecord.totalExposureMinutes = totalMinutes
             localStorage.saveDailyMEDRecord(dailyRecord)
             
             Log.info("오늘 SED 계산 완료: \(String(format: "%.2f", todayTotalSED))")

--- a/StopSun/StopSun/ViewModels/DashboardViewModel.swift
+++ b/StopSun/StopSun/ViewModels/DashboardViewModel.swift
@@ -83,7 +83,7 @@ final class DashboardViewModel {
             return (0..<7).map { offset in
                 let date = calendar.date(byAdding: .day, value: offset - 6, to: today)!
                 let weekday = calendar.component(.weekday, from: date) - 1
-                return WeeklyBarItem(dayLabel: daySymbols[weekday], percent: nil, isToday: offset == 6)
+                return WeeklyBarItem(dayLabel: offset == 6 ? "오늘" : daySymbols[weekday], percent: 0, exposureMinutes: 0, isToday: offset == 6)
             }
         }
         
@@ -94,19 +94,20 @@ final class DashboardViewModel {
             let date = calendar.date(byAdding: .day, value: offset - 6, to: today)!
             let weekday = calendar.component(.weekday, from: date) - 1
             let isToday = offset == 6
-            let label = daySymbols[weekday]
+            let label = isToday ? "오늘" : daySymbols[weekday]
             
             if isToday {
                 let percent = maxSED > 0 ? (todayTotalSED / maxSED) * 100 : 0
-                return WeeklyBarItem(dayLabel: label, percent: percent, isToday: true)
+                let minutes = localStorage.loadDailyMEDRecord(for: date)?.totalExposureMinutes ?? 0
+                return WeeklyBarItem(dayLabel: label, percent: percent, exposureMinutes: minutes, isToday: true)
             }
             
             if let record = localStorage.loadDailyMEDRecord(for: date) {
                 let percent = maxSED > 0 ? (record.totalSED / maxSED) * 100 : 0
-                return WeeklyBarItem(dayLabel: label, percent: percent, isToday: false)
+                return WeeklyBarItem(dayLabel: label, percent: percent, exposureMinutes: record.totalExposureMinutes, isToday: false)
             }
             
-            return WeeklyBarItem(dayLabel: label, percent: nil, isToday: false)
+            return WeeklyBarItem(dayLabel: label, percent: 0, exposureMinutes: 0, isToday: false)
         }
     }
     

--- a/StopSun/StopSun/Views/Chart/WeeklyMEDChartView.swift
+++ b/StopSun/StopSun/Views/Chart/WeeklyMEDChartView.swift
@@ -37,6 +37,8 @@ struct WeeklyMEDChartView: View {
     
     let items: [WeeklyBarItem]
     
+    @State private var selectedIndex: Int?
+    
     private var maxPercent: Double {
         let dataMax = items.compactMap(\.percent).max() ?? 0
         return max(dataMax, 100)
@@ -77,10 +79,12 @@ private extension WeeklyMEDChartView {
     
     var bars: some View {
         HStack(spacing: ChartLayout.barSpacing) {
-            ForEach(items) { item in
+            ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
                 ChartBarColumn(
                     item: item,
-                    maxPercent: maxPercent
+                    maxPercent: maxPercent,
+                    isSelected: selectedIndex == index,
+                    onTap: { selectedIndex = selectedIndex == index ? nil : index }
                 )
             }
         }
@@ -99,8 +103,7 @@ private extension WeeklyMEDChartView {
     
     func dayLabelColor(for item: WeeklyBarItem) -> Color {
         if item.isToday { return .text00 }
-        if item.percent != nil { return .text04 }
-        return .text05
+        return .text04
     }
 }
 
@@ -111,9 +114,11 @@ private struct ChartBarColumn: View {
     
     let item: WeeklyBarItem
     let maxPercent: Double
+    let isSelected: Bool
+    let onTap: () -> Void
     
     private var isOver: Bool {
-        (item.percent ?? 0) >= 100
+        item.percent >= 100
     }
     
     var body: some View {
@@ -121,19 +126,33 @@ private struct ChartBarColumn: View {
             overLabel
             barShape
         }
+        .onTapGesture {
+            onTap()
+        }
     }
     
-    @ViewBuilder
     private var overLabel: some View {
-        if let percent = item.percent {
-            Text("\(Int(percent))%")
-                .font(.ssFont(.M1))
-                .foregroundStyle(isOver ? .text00 : .text04)
-        } else {
-            Text(" ")
-                .font(.ssFont(.M1))
-                .hidden()
+        Group {
+            if isSelected {
+                Text("\(item.exposureMinutes)분")
+                    .font(.ssFont(.M1))
+                    .foregroundStyle(labelColor)
+            } else {
+                Text("\(Int(item.percent))%")
+                    .font(.ssFont(.M1))
+                    .foregroundStyle(labelColor)
+            }
         }
+    }
+    
+    private var labelColor: Color {
+        if item.isToday { return WarningLevel.fromPercentage(item.percent).color }
+        return .text04
+    }
+    
+    private var barColor: Color {
+        if item.isToday { return WarningLevel.fromPercentage(item.percent).color }
+        return isOver ? .chart02 : .chart01
     }
     
     private var barShape: some View {
@@ -142,9 +161,9 @@ private struct ChartBarColumn: View {
                 RoundedRectangle(cornerRadius: ChartLayout.barCornerRadius)
                     .fill(.chart00)
                 
-                if let percent = item.percent, percent > 0 {
+                if item.percent > 0 {
                     RoundedRectangle(cornerRadius: ChartLayout.barCornerRadius)
-                        .fill(isOver ? .chart02 : .chart01)
+                        .fill(barColor)
                         .frame(height: barHeight(in: geo.size.height))
                 }
             }
@@ -153,8 +172,8 @@ private struct ChartBarColumn: View {
     }
     
     private func barHeight(in totalHeight: CGFloat) -> CGFloat {
-        guard let percent = item.percent, percent > 0 else { return 0 }
-        let ratio = min(percent / maxPercent, 1.0)
+        guard item.percent > 0 else { return 0 }
+        let ratio = min(item.percent / maxPercent, 1.0)
         return max(ratio * totalHeight, ChartLayout.minBarHeight)
     }
 }
@@ -163,13 +182,13 @@ private struct ChartBarColumn: View {
 
 #Preview("풀 데이터") {
     WeeklyMEDChartView(items: [
-        .init(dayLabel: "금", percent: 24, isToday: false),
-        .init(dayLabel: "토", percent: 92, isToday: false),
-        .init(dayLabel: "일", percent: 128, isToday: false),
-        .init(dayLabel: "월", percent: 45, isToday: false),
-        .init(dayLabel: "화", percent: 86, isToday: false),
-        .init(dayLabel: "수", percent: 39, isToday: false),
-        .init(dayLabel: "목", percent: 67, isToday: true),
+        .init(dayLabel: "금", percent: 24, exposureMinutes: 18, isToday: false),
+        .init(dayLabel: "토", percent: 92, exposureMinutes: 65, isToday: false),
+        .init(dayLabel: "일", percent: 128, exposureMinutes: 90, isToday: false),
+        .init(dayLabel: "월", percent: 45, exposureMinutes: 32, isToday: false),
+        .init(dayLabel: "화", percent: 86, exposureMinutes: 58, isToday: false),
+        .init(dayLabel: "수", percent: 39, exposureMinutes: 25, isToday: false),
+        .init(dayLabel: "오늘", percent: 12, exposureMinutes: 43, isToday: true),
     ])
     .padding()
     .background(.white01)
@@ -177,13 +196,13 @@ private struct ChartBarColumn: View {
 
 #Preview("설치 3일째") {
     WeeklyMEDChartView(items: [
-        .init(dayLabel: "금", percent: nil, isToday: false),
-        .init(dayLabel: "토", percent: nil, isToday: false),
-        .init(dayLabel: "일", percent: nil, isToday: false),
-        .init(dayLabel: "월", percent: nil, isToday: false),
-        .init(dayLabel: "화", percent: 72, isToday: false),
-        .init(dayLabel: "수", percent: 45, isToday: false),
-        .init(dayLabel: "목", percent: 30, isToday: true),
+        .init(dayLabel: "금", percent: 0, exposureMinutes: 0, isToday: false),
+        .init(dayLabel: "토", percent: 0, exposureMinutes: 0, isToday: false),
+        .init(dayLabel: "일", percent: 0, exposureMinutes: 0, isToday: false),
+        .init(dayLabel: "월", percent: 0, exposureMinutes: 0, isToday: false),
+        .init(dayLabel: "화", percent: 72, exposureMinutes: 48, isToday: false),
+        .init(dayLabel: "수", percent: 45, exposureMinutes: 30, isToday: false),
+        .init(dayLabel: "오늘", percent: 32, exposureMinutes: 43, isToday: true),
     ])
     .padding()
     .background(.white01)
@@ -191,13 +210,27 @@ private struct ChartBarColumn: View {
 
 #Preview("첫날") {
     WeeklyMEDChartView(items: [
-        .init(dayLabel: "금", percent: nil, isToday: false),
-        .init(dayLabel: "토", percent: nil, isToday: false),
-        .init(dayLabel: "일", percent: nil, isToday: false),
-        .init(dayLabel: "월", percent: nil, isToday: false),
-        .init(dayLabel: "화", percent: nil, isToday: false),
-        .init(dayLabel: "수", percent: nil, isToday: false),
-        .init(dayLabel: "목", percent: 18, isToday: true),
+        .init(dayLabel: "금", percent: 0, exposureMinutes: 0, isToday: false),
+        .init(dayLabel: "토", percent: 0, exposureMinutes: 0, isToday: false),
+        .init(dayLabel: "일", percent: 0, exposureMinutes: 0, isToday: false),
+        .init(dayLabel: "월", percent: 0, exposureMinutes: 0, isToday: false),
+        .init(dayLabel: "화", percent: 0, exposureMinutes: 0, isToday: false),
+        .init(dayLabel: "수", percent: 0, exposureMinutes: 0, isToday: false),
+        .init(dayLabel: "오늘", percent: 82, exposureMinutes: 43, isToday: true),
+    ])
+    .padding()
+    .background(.white01)
+}
+
+#Preview("오버") {
+    WeeklyMEDChartView(items: [
+        .init(dayLabel: "금", percent: 0, exposureMinutes: 0, isToday: false),
+        .init(dayLabel: "토", percent: 0, exposureMinutes: 0, isToday: false),
+        .init(dayLabel: "일", percent: 0, exposureMinutes: 0, isToday: false),
+        .init(dayLabel: "월", percent: 0, exposureMinutes: 0, isToday: false),
+        .init(dayLabel: "화", percent: 0, exposureMinutes: 0, isToday: false),
+        .init(dayLabel: "수", percent: 0, exposureMinutes: 0, isToday: false),
+        .init(dayLabel: "오늘", percent: 128, exposureMinutes: 43, isToday: true),
     ])
     .padding()
     .background(.white01)

--- a/StopSun/StopSun/Views/Dashboard/Subview/DashboardMEDCardView.swift
+++ b/StopSun/StopSun/Views/Dashboard/Subview/DashboardMEDCardView.swift
@@ -38,6 +38,7 @@ struct DashboardMEDCardView: View {
                             .font(.ssFont(.R5))
                             .foregroundStyle(.text01)
                     }
+                    .frame(width: 122)
                 }
                 
                 VStack(spacing: 4){
@@ -54,6 +55,7 @@ struct DashboardMEDCardView: View {
                             .font(.ssFont(.R5))
                             .foregroundStyle(.text01)
                     }
+                    .frame(width: 122)
                 }
             }
         }


### PR DESCRIPTION
## ✨ What’s this PR?

- close #56
- close #69 
- close #73 

### 🧶 주요 변경 내용

#### 상단 대시보드 (프로그래스바)
- UV 노출량 정보 사이의 간격 넓힘 → 각 정보 HStack 크기 지정으로 간격 넓힘

#### 주간 자외선 노출 요약
- 차트 라벨에 요일 표시 → 당일은 '오늘'로 변경
-  각 바를 탭하면 노출 시간(분) 표시, 다른 바 탭하면 이동, 같은 바 다시 탭하면 %로 복귀
- 차트 아이템 식별자 uuid → 날짜 기반으로 변경
- 각 MED 레코드에 총 일광시간 저장

#### 주석 제거
- HealthKitManager TODO 주석 제거
- Route TODO 주석은 정보 제공을 위해 MARK 주석으로 변경
- Localization 관련 파트는 수정하지 않았음

---

### 📸 스크린샷 

### 프로그래스바
|전|후|
|-|-|
|<img width="300" alt="전" src="https://github.com/user-attachments/assets/393ab03f-00a3-490b-940e-db4c3ef4bae2">|<img width="300" alt="Simulator Screenshot - iPhone 17 - 2026-03-10 at 17 09 07" src="https://github.com/user-attachments/assets/912a3f7d-6daa-42cf-ae9e-ff3ad41fe1b2" />||

### 차트 뷰
프리뷰 영상 캡처입니다! 시간은 0분으로 입력해놔서 그런 것이니 신경쓰지 않으셔도 됩니다

https://github.com/user-attachments/assets/5faaae2c-b82e-4168-8584-41d0c0470502


---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] iPhone 16, iOS 26.0 환경에서 정상 동작
- [ ] 다크모드 테스트는 이후 이슈로 분리 예정 (#000)

---

### 💬 기타 공유 사항

(없음)