### PR TITLE
💄 Style: #82 대시보드 sticky header 구현

### DIFF
--- a/StopSun/StopSun/Views/Dashboard/DashboardView.swift
+++ b/StopSun/StopSun/Views/Dashboard/DashboardView.swift
@@ -12,6 +12,7 @@ struct DashboardView: View {
     @State private var viewModel: DashboardViewModel
     @Environment(\.scenePhase) private var scenePhase
     @EnvironmentObject private var errorHandler: ErrorHandler
+    @State private var isScrolled = false
 #if DEBUG
     @State private var showDebugSheet = false
 #endif
@@ -48,6 +49,19 @@ struct DashboardView: View {
             .refreshable {
                 await viewModel.pullToRefresh()
             }
+            .onScrollGeometryChange(for: Bool.self) { geo in
+                geo.contentOffset.y + geo.contentInsets.top > 90  // 40 → 90
+            } action: { _, isScrolled in
+                withAnimation(.easeInOut(duration: 0.3)) {
+                    self.isScrolled = isScrolled
+                }
+            }
+        }
+        .overlay(alignment: .top) {
+            if isScrolled {
+                miniHeader
+                    .transition(.move(edge: .top).combined(with: .opacity))
+            }
         }
         .task {
             await viewModel.onAppear()
@@ -80,6 +94,41 @@ struct DashboardView: View {
             DashboardDebugView(syncCoordinator: viewModel.debugSyncCoordinator)
         }
 #endif
+    }
+    
+    // MARK: - Mini Header (스크롤 시)
+    
+    private var miniHeader: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            (
+                Text(L10n.MED.Status.prefix)
+                    .foregroundStyle(.text00) +
+                Text(viewModel.warningLevel.title)
+                    .foregroundStyle(viewModel.warningLevel.color) +
+                Text(L10n.MED.Status.suffix)
+                    .foregroundStyle(viewModel.warningLevel.color)
+            )
+            .font(.ssFont(.SB4))
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 20)
+        .padding(.bottom, 20)
+        .padding(.top, 32)
+        .background(
+            LinearGradient(
+                stops: [
+                    Gradient.Stop(color: .white01, location: 0.00),
+                    Gradient.Stop(color: Color.white01.opacity(0.6), location: 1.00),
+                ],
+                startPoint: UnitPoint(x: 0.5, y: 0),
+                endPoint: UnitPoint(x: 0.5, y: 1)
+            )
+        )
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(Color.white00)
+                .frame(height: 1)
+        }
     }
     
     // MARK: - Header


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?

close #82

### 🧶 주요 변경 내용

#### 대시보드 스크롤 시 sticky header 추가

- 스크롤하면 기존 헤더(날짜, 위험 수준, 추천문구)가 올라간 뒤 위험 수준 텍스트만 상단 고정
- onScrollGeometryChange로 스크롤 offset 감지, overlay로 미니 헤더 표시

---

### 📸 스크린샷 

https://github.com/user-attachments/assets/7da3d6fe-c490-4cd5-92b1-9bbf8c99c335

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] iPhone 16, iOS 26.0 환경에서 정상 동작
- [ ] 다크모드 테스트는 이후 이슈로 분리 예정 (#000)

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- onScrollGeometryChange는 iOS 18+ API
- threshold 값(90)은 headerSection 높이 기준, 폰트 변경 시 조정 필요
