### PR TITLE
🚨 fix: SettingsViewModel이 SyncCoordinator를 통해 프로필 변경 #97

### DIFF
--- a/StopSun/StopSun/Core/DIContainer.swift
+++ b/StopSun/StopSun/Core/DIContainer.swift
@@ -184,7 +184,7 @@ final class DIContainer {
     @MainActor
     func makeSettingsViewModel() -> SettingsViewModel {
         SettingsViewModel(
-            localStorage: localStorage,
+            syncCoordinator: syncCoordinator,
             permissionManager: permissionManager
         )
     }

--- a/StopSun/StopSun/ViewModels/SettingsViewModel.swift
+++ b/StopSun/StopSun/ViewModels/SettingsViewModel.swift
@@ -13,14 +13,14 @@ import UIKit
 /// 사용자 프로필 데이터(SkinType, SPFLevel)를 조회/수정하고,
 /// iOS 설정 앱 이동을 처리합니다.
 ///
+/// - Important: 데이터 변경 후 반드시 `SyncCoordinator`를 통해 수행됩니다.
+///
 @MainActor
 @Observable
 final class SettingsViewModel {
     
     // MARK: - Constants
     
-    /// 외부 URL 상수
-    /// - Note: URL 확정 시 실제 주소로 교체
     enum ExternalURL {
         static let privacy = URL(string: "https://thin-frigate-1a3.notion.site/Privacy-Policy-3044acec465d8053b8e9f6672d1eb47b?source=copy_link")!
         static let support = URL(string: "https://thin-frigate-1a3.notion.site/StopSun-Customer-Support-30b4acec465d8049840ddf6a2c1bb581?source=copy_link")!
@@ -33,21 +33,21 @@ final class SettingsViewModel {
     
     // MARK: - Dependencies
     
-    private let localStorage: any LocalStorageManagerProtocol
+    private let syncCoordinator: any SyncCoordinatorProtocol
     private let permissionManager: PermissionManager
     
     // MARK: - Initializer
     
     init(
-        localStorage: any LocalStorageManagerProtocol,
+        syncCoordinator: any SyncCoordinatorProtocol,
         permissionManager: PermissionManager
     ) {
-        self.localStorage = localStorage
+        self.syncCoordinator = syncCoordinator
         self.permissionManager = permissionManager
         
-        let profile = localStorage.loadUserProfileOrDefault()
-        self.skinType = profile.skinType
-        self.spfLevel = profile.spfLevel
+        let profile = syncCoordinator.userProfile
+        self.skinType = profile?.skinType ?? .type3
+        self.spfLevel = profile?.spfLevel ?? .spf30
         
         Log.debug("SettingsViewModel initialized")
     }
@@ -55,63 +55,53 @@ final class SettingsViewModel {
     // MARK: - Profile Update
     
     /// 피부 타입 변경
+    ///
+    /// `SyncCoordinator`를 통해 변경하여
+    /// localStorage 저장 + 경고 레벨 재계산 + Watch 동기화를 보장합니다.
     func updateSkinType(_ skinType: SkinType) {
-        localStorage.updateSkinType(skinType)
+        syncCoordinator.updateSkinType(skinType)
         self.skinType = skinType
         Log.info("Settings: Skin type updated to \(skinType.title)")
     }
     
     /// SPF 레벨 변경
     func updateSPFLevel(_ spfLevel: SPFLevel) {
-        localStorage.updateSunscreenSPF(spfLevel)
+        syncCoordinator.updateSunScreenSPF(spfLevel)
         self.spfLevel = spfLevel
         Log.info("Settings: SPF updated to \(spfLevel.displayTitle)")
     }
     
     /// 프로필 데이터 새로고침
     func refresh() {
-        let profile = localStorage.loadUserProfileOrDefault()
-        self.skinType = profile.skinType
-        self.spfLevel = profile.spfLevel
+        let profile = syncCoordinator.userProfile
+        self.skinType = profile?.skinType ?? .type3
+        self.spfLevel = profile?.spfLevel ?? .spf30
         Log.debug("Settings: Profile refreshed")
     }
     
     // MARK: - Display Helpers
     
-    /// 현재 피부 타입 표시 텍스트 (예: "4형")
-    var skinTypeDisplayText: String {
-        skinType.title
-    }
-    
-    /// 현재 SPF 표시 텍스트 (예: "SPF 30")
-    var spfDisplayText: String {
-        spfLevel.displayTitle
-    }
+    var skinTypeDisplayText: String { skinType.title }
+    var spfDisplayText: String { spfLevel.displayTitle }
     
     // MARK: - App Info
     
-    /// 개인정보 처리 방침 URL
     var privacyURL: URL { ExternalURL.privacy }
-    
-    /// 앱 정보 및 지원 URL
     var supportURL: URL { ExternalURL.support }
     
-    /// 앱 이름 표시 텍스트 (예: "그만해 - StopSun")
     var appNameText: String {
         let displayName = Bundle.main.infoDictionary?["CFBundleDisplayName"] as? String ?? "-"
         let bundleName = Bundle.main.infoDictionary?["CFBundleName"] as? String ?? "-"
         return "\(displayName) - \(bundleName)"
     }
     
-    /// 앱 버전 표시 텍스트 (예: "v1.0.0")
-       var appVersionText: String {
-           let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "-"
-           return "v\(version)"
-       }
+    var appVersionText: String {
+        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "-"
+        let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "-"
+        return "v\(version) (\(build))"
+    }
     
-    // MARK: - Navigation
-    
-    /// iOS 설정 앱 → 앱 권한 페이지로 이동
+    /// 설정 앱으로 이동
     func openAppSettings() {
         guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
         UIApplication.shared.open(url)

--- a/StopSun/StopSun/Views/Setting/SettingsView.swift
+++ b/StopSun/StopSun/Views/Setting/SettingsView.swift
@@ -376,7 +376,7 @@ struct SettingsView: View {
 #Preview("Settings") {
     SettingsView(
         viewModel: SettingsViewModel(
-            localStorage: MockLocalStorageManager(),
+            syncCoordinator: MockSyncCoordinator(),
             permissionManager: PermissionManager(
                 notification: MockNotificationManager(),
                 healthKit: MockHealthKitManager(),


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?

Closed #97 

localStorage 직접 호출 → SyncCoordinator 를 통하여 변경.
경고 레벨 재계산, Watch 동기화, userProfile 상태 반영 보장.
DIContainer factory 메서드에 반영

### 🧶 주요 변경 내용
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

```
SettingsViewModel.updateSkinType()
    → syncCoordinator.updateSkinType()  ← 여기서 전부 처리
    → self.skinType = skinType          ← VM 내부 상태 동기화
```

- SettingsViewModel.swift 
- DIContainer.swift
- SettingsView.swift

---

### 📸 스크린샷 
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->


---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [ ] 설정에서 피부 타입 변경 후 대시보드 MED 게이지 반영 확인

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- UI 컴포넌트 위치가 디자이너 시안과 다를 수 있어요 → 후속 PR에서 반영 예정
- API 에러 대응 로직은 공통 모듈화하는 작업과 함께 처리할 예정입니다
