### PR TITLE
♻️ Refactor: #104 날짜 간 uvCache 재사용을 위해 calculateRecentSED() 레벨로 스코프 이동

### DIFF
--- a/StopSun/StopSun/Managers/SyncCoordinator.swift
+++ b/StopSun/StopSun/Managers/SyncCoordinator.swift
@@ -368,13 +368,16 @@ private extension SyncCoordinator {
         let sunscreenHistory = localStorage.loadSunscreenHistory()
         let locationHistory = localStorage.loadLocationHistory()
 
+        var uvCache: [String: Double] = [:]
+
         // 과거 → 오늘 순서로 처리 (오늘이 마지막이어야 todayTotalSED 최종 반영)
         for dayOffset in (0...lookbackDays).reversed() {
             guard let date = calendar.date(byAdding: .day, value: -dayOffset, to: today) else { continue }
-            await calculateSED(
+            uvCache = await calculateSED(
                 for: date,
                 sunscreenHistory: sunscreenHistory,
-                locationHistory: locationHistory
+                locationHistory: locationHistory,
+                uvCache: uvCache
             )
         }
     }
@@ -386,13 +389,16 @@ private extension SyncCoordinator {
     func calculateSED(
         for date: Date,
         sunscreenHistory: [SunscreenApplication],
-        locationHistory: [LocationRecord]
-    ) async {
+        locationHistory: [LocationRecord],
+        uvCache: [String: Double]
+    ) async -> [String: Double] {
         let calendar = Calendar.current
         let startOfDay = calendar.startOfDay(for: date)
         let endOfDay = calendar.isDateInToday(date)
             ? Date()
             : calendar.date(byAdding: .day, value: 1, to: startOfDay)!
+
+        var cache = uvCache
 
         do {
             let timeInDaylightData = try await healthKit.fetchTimeInDaylight(from: startOfDay, to: endOfDay)
@@ -400,7 +406,6 @@ private extension SyncCoordinator {
             var runningTotal = existingRecords.reduce(0) { $0 + $1.receivedSED }
 
             let processedIDs = Set(existingRecords.compactMap(\.healthKitID))
-            var uvCache: [String: Double] = [:]
 
             var newCount = 0
             var totalMinutes = 0
@@ -423,7 +428,7 @@ private extension SyncCoordinator {
                 let cacheKey = "\(String(format: "%.2f", locationInfo.latitude)),\(String(format: "%.2f", locationInfo.longitude))-\(calendar.component(.hour, from: data.startTime))"
 
                 let uvIndex: Double
-                if let cached = uvCache[cacheKey] {
+                if let cached = cache[cacheKey] {
                     uvIndex = cached
                 } else {
                     do {
@@ -432,7 +437,7 @@ private extension SyncCoordinator {
                         Log.error("과거 UV 조회 실패: \(error.localizedDescription)")
                         uvIndex = currentUVIndex
                     }
-                    uvCache[cacheKey] = uvIndex
+                    cache[cacheKey] = uvIndex
                 }
 
                 let sed = SEDCalculator.calculateWithSunscreenHistory(
@@ -478,6 +483,8 @@ private extension SyncCoordinator {
                 self.error = .healthKit(.dataFetchFailed)
             }
         }
+
+        return cache
     }
 }
 

--- a/StopSun/StopSun/Managers/SyncCoordinator.swift
+++ b/StopSun/StopSun/Managers/SyncCoordinator.swift
@@ -425,7 +425,7 @@ private extension SyncCoordinator {
                     ?? currentWeather?.location
                     ?? .mockSeoul
 
-                let cacheKey = "\(String(format: "%.2f", locationInfo.latitude)),\(String(format: "%.2f", locationInfo.longitude))-\(calendar.component(.hour, from: data.startTime))"
+                let cacheKey = "\(String(format: "%.2f", locationInfo.latitude)),\(String(format: "%.2f", locationInfo.longitude))-\(date.toAPIDateString)-\(calendar.component(.hour, from: data.startTime))"
 
                 let uvIndex: Double
                 if let cached = cache[cacheKey] {


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

close #104

## ✨ What’s this PR?

### 🧶 주요 변경 내용
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- uvCache를 calculateSED() 로컬에서 calculateRecentSED() 레벨로 이동
- calculateSED()가 uvCache를 파라미터로 받고 업데이트된 캐시를 반환하도록 시그니처 변경
- 7일치 루프 전체에서 동일 위치·시간대 history API 중복 호출 방지

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] 첫 sync 시 7일치 SED 정상 계산 확인
- [ ] 동일 위치·시간대 레코드에서 캐시 히트 확인 (Log.debug로 확인)
- [x] 기존 SED 계산 결과값 동일 여부 확인