### PR TITLE
♻️ Refactor: #103 Dashboard 레이어 불필요한 반복 연산 및 이중 진입점 정리

### DIFF
--- a/StopSun/StopSun/ViewModels/DashboardViewModel.swift
+++ b/StopSun/StopSun/ViewModels/DashboardViewModel.swift
@@ -22,7 +22,12 @@ final class DashboardViewModel {
     
     /// 캐싱된 날짜 문자열 (하루에 한 번만 갱신)
     private(set) var formattedDate: String = ""
-    
+    private(set) var weeklyChartItems: [WeeklyBarItem] = []
+
+    // MARK: - Private Cache State
+
+    private var lastBuiltDate: Date?
+
     // MARK: - Dependencies
     
     private let syncCoordinator: SyncCoordinator
@@ -67,25 +72,122 @@ final class DashboardViewModel {
     var syncError: AppError? {
         syncCoordinator.error
     }
-    
+
+    // MARK: - Weather Data
+
+    var uvIndex: Int {
+        Int(syncCoordinator.currentWeather?.currentUVIndex ?? 0)
+    }
+
+    var temperature: Double {
+        syncCoordinator.currentWeather?.currentTemperature ?? 0
+    }
+
+    var locationName: String {
+        syncCoordinator.currentWeather?.location.cityName ?? "—"
+    }
+
+    // MARK: - Sunscreen Timer
+
+    var isTimerActive: Bool {
+        guard let sunscreen = syncCoordinator.activeSunscreen else { return false }
+        return sunscreen.isActive(at: Date())
+    }
+
+    func timerRemaining(at now: Date) -> String {
+        guard let sunscreen = syncCoordinator.activeSunscreen,
+              sunscreen.isActive(at: now)
+        else {
+            return "00:00"
+        }
+
+        let remaining = sunscreen.nextReapplyTime.timeIntervalSince(now)
+        guard remaining > 0 else { return "00:00" }
+
+        let hours = Int(remaining) / 3600
+        let minutes = (Int(remaining) % 3600) / 60
+        let seconds = Int(remaining) % 60
+
+        if hours > 0 {
+            return String(format: "%d:%02d:%02d", hours, minutes, seconds)
+        } else {
+            return String(format: "%02d:%02d", minutes, seconds)
+        }
+    }
+
+    // MARK: - Actions
+
+    func onAppear() async {
+        formattedDate = Date().toDayWithWeekdayString
+        refreshWeeklyChartItemsIfNeeded()
+
+        guard let lastSync = syncCoordinator.lastSyncTime else {
+            await syncCoordinator.startSync()
+            refreshWeeklyChartItems()
+            return
+        }
+
+        if Date().timeIntervalSince(lastSync) > resyncInterval {
+            await syncCoordinator.startSync()
+            refreshWeeklyChartItems()
+        }
+    }
+
+    func pullToRefresh() async {
+        await syncCoordinator.refresh()
+        refreshWeeklyChartItems()
+    }
+
     // MARK: - Weekly Chart
-    
-    /// 최근 7일간 MED 차트 데이터 조회
-    ///
-    /// LocalStorage에서 DailyMEDRecord를 읽어 WeeklyBarItem 배열로 변환합니다.
-    /// 오늘 데이터는 SyncCoordinator의 실시간 값을 사용합니다.
-    var weeklyChartItems: [WeeklyBarItem] {
+
+    private func refreshWeeklyChartItemsIfNeeded() {
+        let today = Calendar.current.startOfDay(for: Date())
+
+        guard let lastBuilt = lastBuiltDate,
+              Calendar.current.isDate(lastBuilt, inSameDayAs: today)
+        else {
+            // 날짜 바뀌었거나 최초 진입 → 전체 재계산
+            refreshWeeklyChartItems()
+            return
+        }
+
+        // 같은 날이면 오늘 항목만 업데이트
+        updateTodayItem()
+    }
+
+    private func refreshWeeklyChartItems() {
+        weeklyChartItems = buildWeeklyChartItems()
+        lastBuiltDate = Calendar.current.startOfDay(for: Date())
+    }
+
+    private func updateTodayItem() {
+        guard !weeklyChartItems.isEmpty,
+              let skinType = syncCoordinator.userProfile?.skinType
+        else { return }
+
+        let maxSED = skinType.maxDailyMEDinSED
+        let percent = maxSED > 0 ? (syncCoordinator.todayTotalSED / maxSED) * 100 : 0
+        let today = Calendar.current.startOfDay(for: Date())
+        let minutes = localStorage.loadDailyMEDRecord(for: today)?.totalExposureMinutes ?? 0
+
+        weeklyChartItems[6] = WeeklyBarItem(
+            dayLabel: weeklyChartItems[6].dayLabel,
+            percent: percent,
+            exposureMinutes: minutes,
+            isToday: true
+        )
+    }
+
+    private func buildWeeklyChartItems() -> [WeeklyBarItem] {
         let calendar = Calendar.current
         let today = calendar.startOfDay(for: Date())
-        
+
         let isEnglish = Locale.current.language.languageCode?.identifier == "en"
-        
         let daySymbols = isEnglish
-        ? ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"]
-        : ["일", "월", "화", "수", "목", "금", "토"]
-        
+            ? ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"]
+            : ["일", "월", "화", "수", "목", "금", "토"]
         let todayLabel = isEnglish ? "TODAY" : "오늘"
-        
+
         guard let skinType = syncCoordinator.userProfile?.skinType else {
             return (0..<7).map { offset in
                 let date = calendar.date(byAdding: .day, value: offset - 6, to: today)!
@@ -98,95 +200,30 @@ final class DashboardViewModel {
                 )
             }
         }
-        
+
         let maxSED = skinType.maxDailyMEDinSED
-        let todayTotalSED = syncCoordinator.todayTotalSED
-        
+
         return (0..<7).map { offset in
             let date = calendar.date(byAdding: .day, value: offset - 6, to: today)!
             let weekday = calendar.component(.weekday, from: date) - 1
             let isToday = offset == 6
             let label = isToday ? todayLabel : daySymbols[weekday]
-            
+
             if isToday {
-                let percent = maxSED > 0 ? (todayTotalSED / maxSED) * 100 : 0
+                let percent = maxSED > 0 ? (syncCoordinator.todayTotalSED / maxSED) * 100 : 0
                 let minutes = localStorage.loadDailyMEDRecord(for: date)?.totalExposureMinutes ?? 0
                 return WeeklyBarItem(dayLabel: label, percent: percent, exposureMinutes: minutes, isToday: true)
             }
-            
+
             if let record = localStorage.loadDailyMEDRecord(for: date) {
                 let percent = maxSED > 0 ? (record.totalSED / maxSED) * 100 : 0
                 return WeeklyBarItem(dayLabel: label, percent: percent, exposureMinutes: record.totalExposureMinutes, isToday: false)
             }
-            
+
             return WeeklyBarItem(dayLabel: label, percent: 0, exposureMinutes: 0, isToday: false)
         }
     }
-    
-    // MARK: - Weather Data
-    
-    var uvIndex: Int {
-        Int(syncCoordinator.currentWeather?.currentUVIndex ?? 0)
-    }
-    
-    var temperature: Double {
-        syncCoordinator.currentWeather?.currentTemperature ?? 0
-    }
-    
-    var locationName: String {
-        syncCoordinator.currentWeather?.location.cityName ?? "—"
-    }
-    
-    // MARK: - Sunscreen Timer
-    
-    var isTimerActive: Bool {
-        guard let sunscreen = syncCoordinator.activeSunscreen else { return false }
-        return sunscreen.isActive(at: Date())
-    }
-    
-    /// 남은 시간 포맷 (TimelineView에서 now를 전달받아 사용)
-    func timerRemaining(at now: Date) -> String {
-        guard let sunscreen = syncCoordinator.activeSunscreen,
-              sunscreen.isActive(at: now)
-        else {
-            return "00:00"
-        }
-        
-        let remaining = sunscreen.nextReapplyTime.timeIntervalSince(now)
-        guard remaining > 0 else { return "00:00" }
-        
-        let hours = Int(remaining) / 3600
-        let minutes = (Int(remaining) % 3600) / 60
-        let seconds = Int(remaining) % 60
-        
-        if hours > 0 {
-            return String(format: "%d:%02d:%02d", hours, minutes, seconds)
-        } else {
-            return String(format: "%02d:%02d", minutes, seconds)
-        }
-    }
-    
-    // MARK: - Actions
-    
-    /// 최초 진입 또는 포그라운드 복귀 시 호출
-    func onAppear() async {
-        formattedDate = Date().toDayWithWeekdayString
-        
-        guard let lastSync = syncCoordinator.lastSyncTime else {
-            await syncCoordinator.startSync()
-            return
-        }
-        
-        if Date().timeIntervalSince(lastSync) > resyncInterval {
-            await syncCoordinator.startSync()
-        }
-    }
-    
-    /// Pull-to-refresh
-    func pullToRefresh() async {
-        await syncCoordinator.refresh()
-    }
-    
+
     // MARK: - Debug
     
     #if DEBUG

--- a/StopSun/StopSun/Views/Dashboard/DashboardView.swift
+++ b/StopSun/StopSun/Views/Dashboard/DashboardView.swift
@@ -63,10 +63,7 @@ struct DashboardView: View {
                     .transition(.move(edge: .top).combined(with: .opacity))
             }
         }
-        .task {
-            await viewModel.onAppear()
-        }
-        .onChange(of: scenePhase) { _, newPhase in
+        .onChange(of: scenePhase, initial: true) { _, newPhase in
             if newPhase == .active {
                 Task { await viewModel.onAppear() }
             }


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

close #103 

## ✨ What’s this PR?

### 🧶 주요 변경 내용
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- weeklyChartItems를 computed property에서 stored property로 전환
- 날짜 바뀌면 전체 재계산, 같은 날이면 오늘 항목만 업데이트 (과거 6일 decode 스킵)
- DashboardView .task { onAppear() } 제거, .onChange(of: scenePhase, initial: true)로 진입점 단일화

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] 앱 최초 진입 시 차트 정상 표시 확인
- [ ] 날짜 변경 후 재진입 시 전체 차트 갱신 확인
- [x] 같은 날 재진입 시 오늘 항목만 업데이트 확인
- [x] pull-to-refresh 후 차트 갱신 확인
