### PR TITLE
🐛 Bug: #109 백그라운드 상태에서 선크림 재도포 및 MED 경고 알림 미수신

### DIFF
--- a/StopSun/StopSun/Managers/NotificationManager.swift
+++ b/StopSun/StopSun/Managers/NotificationManager.swift
@@ -150,8 +150,8 @@ final class NotificationManager: NSObject, NotificationManagerProtocol {
         content.body = L10n.Notification.Reapply.body
         content.sound = .default
         content.categoryIdentifier = NotificationCategory.reapply
-        content.interruptionLevel = .timeSensitive
-        
+        content.interruptionLevel = .active
+
         let components = Calendar.current.dateComponents(
             [.year, .month, .day, .hour, .minute, .second],
             from: date
@@ -222,29 +222,33 @@ final class NotificationManager: NSObject, NotificationManagerProtocol {
         case 50:
             content.title = L10n.Notification.MED.title50
             content.body = L10n.Notification.MED.body50
-            content.interruptionLevel = .timeSensitive
-            
+            content.interruptionLevel = .active
+
         case 70:
             content.title = L10n.Notification.MED.title70
             content.body = L10n.Notification.MED.body70
-            content.interruptionLevel = .timeSensitive
-            
+            content.interruptionLevel = .active
+
         case 100:
             content.title = L10n.Notification.MED.title100
             content.body = L10n.Notification.MED.body100
-            content.interruptionLevel = .critical
-            
+            content.interruptionLevel = .active
+
         default:
             return
         }
         
         let identifier = "stopsun.notification.med.\(threshold)"
+        let trigger = UNTimeIntervalNotificationTrigger(
+            timeInterval: 0.1,
+            repeats: false
+        )
         let request = UNNotificationRequest(
             identifier: identifier,
             content: content,
-            trigger: nil // 즉시 발송
+            trigger: trigger
         )
-        
+
         Task {
             do {
                 try await notificationCenter.add(request)


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

close #109

## ✨ What’s this PR?

### 🧶 주요 변경 내용
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

**1. MED 경고 알림 trigger: nil → UNTimeIntervalNotificationTrigger 교체**

`trigger: nil`은 UNUserNotificationCenter에서 "즉시 전달"을 의미하는데, iOS에서 즉시 전달은 앱이 포그라운드일 때만 동작해서 백그라운드 상태에서는 iOS가 trigger: nil 알림을 전달하지 않는다고 합니다.

`UNTimeIntervalNotificationTrigger(timeInterval: 0.1, repeats: false)`로 교체하면 0.1초 후 전달되는 예약 알림으로 처리되어 백그라운드에서도 정상 전달됩니다!

**2. interruptionLevel 하향**

모두 .active 레벨로 하향 조정했습니다. criticial이랑 timeSensitive는 별도의 승인이 필요한 레벨이라고 하네요!


---

### 📸 스크린샷 
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

건강 앱에서 데이터 밀어넣었을 때 앱 밖에서 잘 뜨는 것 확인 했음

<img width="300" alt="EBF25250-C833-45D8-8EFA-11907E0F8BAB_1_102_o" src="https://github.com/user-attachments/assets/708cedde-5fbf-4ad7-abb3-4b10f6433ab5" />

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] 앱 백그라운드 상태에서 MED 경고 알림 수신 확인
- [ ] 앱 백그라운드 상태에서 재도포 알림 수신 확인
