### PR TITLE
✨ Feature: 설정탭에서 워치 연동 확인 기능 추가

### DIFF
--- a/StopSun/Shared/Resources/DesignSystem/Localization/L10n.swift
+++ b/StopSun/Shared/Resources/DesignSystem/Localization/L10n.swift
@@ -453,11 +453,17 @@ enum L10n {
             static var title: String { .localized("settings.spf.title") }
             static var desc: String { .localized("settings.spf.desc") }
         }
-
+        
         enum Daylight {
             static var title: String { .localized("settings.daylight.title") }
             static var desc: String { .localized("settings.daylight.desc") }
             static var open: String { .localized("settings.daylight.open") }
+        }
+        
+        enum WatchSetting {
+            static var title: String { .localized("settings.watch.title") }
+            static var desc: String { .localized("settings.watch.desc") }
+            static var check: String { .localized("settings.watch.check") }
         }
         
         enum AppInfo {
@@ -465,7 +471,7 @@ enum L10n {
             static var support: String { .localized("settings.appInfo.support") }
         }
     }
-
+    
     // MARK: - Timer
     
     enum Timer {

--- a/StopSun/Shared/Resources/DesignSystem/Localization/L10n.swift
+++ b/StopSun/Shared/Resources/DesignSystem/Localization/L10n.swift
@@ -389,8 +389,10 @@ enum L10n {
         
         /// 타이머 카드
         enum Card {
-            /// "선크림 타이머를\n워치에서 작동시켜주세요"
             static var watchPrompt: String { .localized("sunscreen.card.watchPrompt") }
+            static var inactive: String { .localized("sunscreen.card.inactive") }
+            static var start: String { .localized("sunscreen.card.start") }
+            static var stop: String { .localized("sunscreen.card.stop") }
         }
     }
     

--- a/StopSun/Shared/Resources/DesignSystem/Localization/L10n.swift
+++ b/StopSun/Shared/Resources/DesignSystem/Localization/L10n.swift
@@ -468,6 +468,15 @@ enum L10n {
             static var check: String { .localized("settings.watch.check") }
         }
         
+        enum WatchAlert {
+            static var alreadyConnectedTitle: String   { .localized("settings.watch.alert.alreadyConnected.title") }
+            static var alreadyConnectedMessage: String { .localized("settings.watch.alert.alreadyConnected.message") }
+            static var connectedTitle: String          { .localized("settings.watch.alert.connected.title") }
+            static var connectedMessage: String        { .localized("settings.watch.alert.connected.message") }
+            static var notPairedTitle: String          { .localized("settings.watch.alert.notPaired.title") }
+            static var notPairedMessage: String        { .localized("settings.watch.alert.notPaired.message") }
+        }
+        
         enum AppInfo {
             static var privacy: String { .localized("settings.appInfo.privacy") }
             static var support: String { .localized("settings.appInfo.support") }

--- a/StopSun/Shared/Resources/Localizable.xcstrings
+++ b/StopSun/Shared/Resources/Localizable.xcstrings
@@ -2832,6 +2832,27 @@
         }
       }
     },
+    "settings.watch.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Apple Watch Connection" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "애플 워치 연동 확인" } }
+      }
+    },
+    "settings.watch.desc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Check and save your Apple Watch connection status." } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "애플 워치와의 연동 상태를 확인하고 저장해요." } }
+      }
+    },
+    "settings.watch.check" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Check" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "확인" } }
+      }
+    },
     "settings.title" : {
       "comment" : "설정 화면 타이틀",
       "extractionState" : "manual",

--- a/StopSun/Shared/Resources/Localizable.xcstrings
+++ b/StopSun/Shared/Resources/Localizable.xcstrings
@@ -3318,6 +3318,27 @@
         }
       }
     },
+    "sunscreen.card.inactive" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Time to apply sunscreen" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "선크림을 도포해주세요" } }
+      }
+    },
+    "sunscreen.card.start" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Apply Sunscreen" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "선크림 도포" } }
+      }
+    },
+    "sunscreen.card.stop" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Stop Timer" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "타이머 종료" } }
+      }
+    },
     "sunscreen.effectiveness.excellent" : {
       "comment" : "선크림 효과 상태: 매우 좋음 (80-100%)",
       "extractionState" : "manual",

--- a/StopSun/Shared/Resources/Localizable.xcstrings
+++ b/StopSun/Shared/Resources/Localizable.xcstrings
@@ -2853,6 +2853,108 @@
         "ko" : { "stringUnit" : { "state" : "translated", "value" : "확인" } }
       }
     },
+    "settings.watch.alert.alreadyConnected.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Already Connected"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이미 연결되어 있어요"
+          }
+        }
+      }
+    },
+    "settings.watch.alert.alreadyConnected.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your Apple Watch is already connected."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "애플 워치가 정상적으로 연동되어 있어요."
+          }
+        }
+      }
+    },
+    "settings.watch.alert.connected.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connected"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "연결됐어요"
+          }
+        }
+      }
+    },
+    "settings.watch.alert.connected.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apple Watch connection confirmed.\nUV data will now be received from your Watch."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "애플 워치 연동이 확인됐어요.\n자외선 데이터를 워치에서 받아올 수 있어요."
+          }
+        }
+      }
+    },
+    "settings.watch.alert.notPaired.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Watch Not Connected"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "워치가 연결되지 않았어요"
+          }
+        }
+      }
+    },
+    "settings.watch.alert.notPaired.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No paired Apple Watch found.\nPlease check your Watch connection."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "페어링된 애플 워치를 찾지 못했어요.\n워치 연결 상태를 확인해주세요."
+          }
+        }
+      }
+    },
     "settings.title" : {
       "comment" : "설정 화면 타이틀",
       "extractionState" : "manual",

--- a/StopSun/Shared/Resources/Localizable.xcstrings
+++ b/StopSun/Shared/Resources/Localizable.xcstrings
@@ -3322,21 +3322,21 @@
       "extractionState" : "manual",
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Time to apply sunscreen" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "선크림을 도포해주세요" } }
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "선크림을 다시 바를 수 있도록 알려줄게요" } }
       }
     },
     "sunscreen.card.start" : {
       "extractionState" : "manual",
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Apply Sunscreen" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "선크림 도포" } }
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "선크림 모드 시작" } }
       }
     },
     "sunscreen.card.stop" : {
       "extractionState" : "manual",
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Stop Timer" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "타이머 종료" } }
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "선크림 모드 종료" } }
       }
     },
     "sunscreen.effectiveness.excellent" : {

--- a/StopSun/StopSun/Managers/LocalStorageManager.swift
+++ b/StopSun/StopSun/Managers/LocalStorageManager.swift
@@ -9,37 +9,38 @@ import Foundation
 
 /// 로컬 저장소 관리자
 final class LocalStorageManager: LocalStorageManagerProtocol {
-
+    
     // MARK: - Properties
-
+    
     private let userDefaults: UserDefaults
-
+    
     // UserProfile Keys
     private let profileKey = "userProfile"
     private let onboardingCompletedKey = "isOnboardingCompleted"
     private let firstLaunchKey = "isFirstLaunch"
-
+    
     // Sunscreen Keys
     private let sunscreenHistoryKey = "sunscreenHistory"
-
+    private let sunscreenManualStopKey = "sunscreenManualStopTime"
+    
     // Location Keys
     private let locationHistoryKey = "locationHistory"
-
+    
     // MARK: - Initialization
-
+    
     init(userDefaults: UserDefaults = .standard) {
         self.userDefaults = userDefaults
         Log.debug("LocalStorageManager initialized")
     }
-
+    
     // MARK: - UserProfile
-
+    
     func loadUserProfile() -> UserProfile? {
         guard let data = userDefaults.data(forKey: profileKey) else {
             Log.debug("No UserProfile found in UserDefaults")
             return nil
         }
-
+        
         do {
             let profile = try JSONDecoder().decode(UserProfile.self, from: data)
             Log.debug("UserProfile loaded successfully")
@@ -49,7 +50,7 @@ final class LocalStorageManager: LocalStorageManagerProtocol {
             return nil
         }
     }
-
+    
     func loadUserProfileOrDefault() -> UserProfile {
         guard let profile = loadUserProfile() else {
             Log.debug("Returning default UserProfile")
@@ -57,13 +58,13 @@ final class LocalStorageManager: LocalStorageManagerProtocol {
         }
         return profile
     }
-
+    
     func saveUserProfile(_ profile: UserProfile) {
         do {
             let encoded = try JSONEncoder().encode(profile)
             userDefaults.set(encoded, forKey: profileKey)
             Log.info("UserProfile saved successfully: \(profile)")
-
+            
             NotificationCenter.default.post(
                 name: .userProfileDidChange,
                 object: profile
@@ -72,14 +73,14 @@ final class LocalStorageManager: LocalStorageManagerProtocol {
             Log.error("Failed to save UserProfile: \(error.localizedDescription)")
         }
     }
-
+    
     func updateSkinType(_ skinType: SkinType) {
         var profile = loadUserProfileOrDefault()
         profile.skinType = skinType
         Log.info("Updating SkinType to: \(skinType.title)")
         saveUserProfile(profile)
     }
-
+    
     func updateSunscreenSPF(_ spfLevel: SPFLevel) {
         var profile = loadUserProfileOrDefault()
         profile.spfLevel = spfLevel
@@ -88,52 +89,52 @@ final class LocalStorageManager: LocalStorageManagerProtocol {
     }
     
     func updateHasWatch(_ isPaired: Bool) {
-            var profile = loadUserProfileOrDefault()
-            profile.hasWatch = isPaired
-            Log.info("Updating hasWatch to: \(isPaired)")
-            saveUserProfile(profile)
-        }
-
+        var profile = loadUserProfileOrDefault()
+        profile.hasWatch = isPaired
+        Log.info("Updating hasWatch to: \(isPaired)")
+        saveUserProfile(profile)
+    }
+    
     func deleteUserProfile() {
         userDefaults.removeObject(forKey: profileKey)
         Log.info("UserProfile deleted")
-
+        
         NotificationCenter.default.post(
             name: .userProfileDidChange,
             object: nil
         )
     }
-
+    
     func saveOnboardingCompleted(_ isCompleted: Bool) {
         userDefaults.set(isCompleted, forKey: onboardingCompletedKey)
         Log.info("Onboarding completed status saved: \(isCompleted)")
     }
-
+    
     func loadOnboardingCompleted() -> Bool {
         return userDefaults.bool(forKey: onboardingCompletedKey)
     }
-
+    
     func checkIsFirstLaunch() -> Bool {
         let isFirst = !userDefaults.bool(forKey: firstLaunchKey)
-
+        
         guard isFirst else {
             return false
         }
-
+        
         userDefaults.set(true, forKey: firstLaunchKey)
         Log.info("First launch detected and recorded")
-
+        
         return true
     }
     
     // MARK: - SunscreenApplication
-
+    
     func loadSunscreenHistory() -> [SunscreenApplication] {
         guard let data = userDefaults.data(forKey: sunscreenHistoryKey) else {
             Log.debug("No Sunscreen history found in UserDefaults")
             return []
         }
-
+        
         do {
             let history = try JSONDecoder().decode([SunscreenApplication].self, from: data)
             Log.debug("Sunscreen history loaded: \(history.count) items")
@@ -143,21 +144,21 @@ final class LocalStorageManager: LocalStorageManagerProtocol {
             return []
         }
     }
-
+    
     func loadCurrentSunscreen() -> SunscreenApplication? {
         let history = loadSunscreenHistory()
         return history.last
     }
-
+    
     func saveSunscreenApplication(_ application: SunscreenApplication) {
         var history = loadSunscreenHistory()
         history.append(application)
-
+        
         // 메모리 관리: 최근 1000개만 유지
         if history.count > 1000 {
             history.removeFirst(history.count - 1000)
         }
-
+        
         do {
             let encoded = try JSONEncoder().encode(history)
             userDefaults.set(encoded, forKey: sunscreenHistoryKey)
@@ -166,12 +167,28 @@ final class LocalStorageManager: LocalStorageManagerProtocol {
             Log.error("Failed to save Sunscreen application: \(error.localizedDescription)")
         }
     }
-
+    
     func deleteSunscreen() {
         userDefaults.removeObject(forKey: sunscreenHistoryKey)
         Log.info("Sunscreen history deleted")
     }
-
+    
+    func saveManualSunscreenStopTime(_ date: Date) {
+        userDefaults.set(date.timeIntervalSince1970, forKey: sunscreenManualStopKey)
+        Log.info("선크림 수동 종료 시각 저장: \(date.formatted(date: .omitted, time: .shortened))")
+    }
+    
+    func loadManualSunscreenStopTime() -> Date? {
+        let raw = userDefaults.double(forKey: sunscreenManualStopKey)
+        guard raw > 0 else { return nil }
+        return Date(timeIntervalSince1970: raw)
+    }
+    
+    func clearManualSunscreenStopTime() {
+        userDefaults.removeObject(forKey: sunscreenManualStopKey)
+        Log.debug("선크림 수동 종료 시각 초기화")
+    }
+    
     func isSunscreenActive() -> Bool {
         guard let current = loadCurrentSunscreen() else {
             return false
@@ -180,19 +197,19 @@ final class LocalStorageManager: LocalStorageManagerProtocol {
         Log.debug("Sunscreen active status: \(isActive)")
         return isActive
     }
-
+    
     func loadSunscreenRemainingMinutes() -> Int {
         guard let current = loadCurrentSunscreen() else {
             return 0
         }
-
+        
         let currentTime = Date()
         let nextReapplyTime = current.nextReapplyTime
         let remainingTime = nextReapplyTime.timeIntervalSince(currentTime)
-
+        
         return remainingTime > 0 ? Int(remainingTime / 60) : 0
     }
-
+    
     func getActiveSPF(at date: Date) -> SPFLevel {
         let history = loadSunscreenHistory()
         let activeSunscreen = history.first { $0.isActive(at: date) }
@@ -200,13 +217,13 @@ final class LocalStorageManager: LocalStorageManagerProtocol {
     }
     
     // MARK: - LocationRecord
-
+    
     func loadLocationHistory() -> [LocationRecord] {
         guard let data = userDefaults.data(forKey: locationHistoryKey) else {
             Log.debug("No Location history found in UserDefaults")
             return []
         }
-
+        
         do {
             let history = try JSONDecoder().decode([LocationRecord].self, from: data)
             Log.debug("Location history loaded: \(history.count) items")
@@ -216,16 +233,16 @@ final class LocalStorageManager: LocalStorageManagerProtocol {
             return []
         }
     }
-
+    
     func saveLocationRecord(_ record: LocationRecord) {
         var history = loadLocationHistory()
         history.append(record)
-
+        
         // 메모리 관리: 최근 1000개만 유지
         if history.count > 1000 {
             history.removeFirst(history.count - 1000)
         }
-
+        
         do {
             let encoded = try JSONEncoder().encode(history)
             userDefaults.set(encoded, forKey: locationHistoryKey)
@@ -234,10 +251,10 @@ final class LocalStorageManager: LocalStorageManagerProtocol {
             Log.error("Failed to save Location record: \(error.localizedDescription)")
         }
     }
-
+    
     func getLocation(at date: Date) -> LocationRecord? {
         let history = loadLocationHistory()
-
+        
         // 10분 오차 범위 내 가장 가까운 기록 반환
         // HealthKit 데이터 지연을 고려한 여유값
         return history.last { record in
@@ -246,14 +263,14 @@ final class LocalStorageManager: LocalStorageManagerProtocol {
     }
     
     // MARK: - UVExposureRecord
-
+    
     func loadExposureRecords(for date: Date) -> [UVExposureRecord] {
         let key = exposureKey(for: date)
         guard let data = userDefaults.data(forKey: key) else {
             Log.debug("No UV Exposure records found for \(date.formatted(date: .abbreviated, time: .omitted))")
             return []
         }
-
+        
         do {
             let records = try JSONDecoder().decode([UVExposureRecord].self, from: data)
             Log.debug("UV Exposure records loaded: \(records.count) items for \(date.formatted(date: .abbreviated, time: .omitted))")
@@ -263,20 +280,20 @@ final class LocalStorageManager: LocalStorageManagerProtocol {
             return []
         }
     }
-
+    
     func saveExposureRecord(_ record: UVExposureRecord) {
         let key = exposureKey(for: record.startTime)
         var records = loadExposureRecords(for: record.startTime)
-
+        
         // 중복 저장 방지: HealthKit ID가 이미 존재하는지 확인
         if let healthKitID = record.healthKitID,
            records.contains(where: { $0.healthKitID == healthKitID }) {
             Log.debug("UV Exposure record already exists: \(healthKitID)")
             return
         }
-
+        
         records.append(record)
-
+        
         do {
             let encoded = try JSONEncoder().encode(records)
             userDefaults.set(encoded, forKey: key)
@@ -285,39 +302,39 @@ final class LocalStorageManager: LocalStorageManagerProtocol {
             Log.error("Failed to save UV Exposure record: \(error.localizedDescription)")
         }
     }
-
+    
     func isProcessed(healthKitID: UUID) -> Bool {
         let calendar = Calendar.current
         let today = Date()
-
+        
         // 1. 당일 데이터 먼저 확인 (대부분의 케이스)
         let todayRecords = loadExposureRecords(for: today)
         if todayRecords.contains(where: { $0.healthKitID == healthKitID }) {
             return true
         }
-
+        
         // 2. 당일에 없으면 과거 검색 (지연 도착 케이스)
         for dayOffset in 1...30 {
             guard let date = calendar.date(byAdding: .day, value: -dayOffset, to: today) else { continue }
             let records = loadExposureRecords(for: date)
-
+            
             if records.contains(where: { $0.healthKitID == healthKitID }) {
                 return true
             }
         }
-
+        
         return false
     }
     
     // MARK: - DailyMEDRecord
-
+    
     func loadDailyMEDRecord(for date: Date) -> DailyMEDRecord? {
         let key = dailyMEDKey(for: date)
         guard let data = userDefaults.data(forKey: key) else {
             Log.debug("No Daily MED record found for \(date.formatted(date: .abbreviated, time: .omitted))")
             return nil
         }
-
+        
         do {
             let record = try JSONDecoder().decode(DailyMEDRecord.self, from: data)
             Log.debug("Daily MED record loaded: \(record.totalSED) SED for \(date.formatted(date: .abbreviated, time: .omitted))")
@@ -327,10 +344,10 @@ final class LocalStorageManager: LocalStorageManagerProtocol {
             return nil
         }
     }
-
+    
     func saveDailyMEDRecord(_ record: DailyMEDRecord) {
         let key = dailyMEDKey(for: record.date)
-
+        
         do {
             let encoded = try JSONEncoder().encode(record)
             userDefaults.set(encoded, forKey: key)
@@ -341,24 +358,24 @@ final class LocalStorageManager: LocalStorageManagerProtocol {
     }
     
     // MARK: - Cleanup
-
+    
     func cleanupOldData() {
         let calendar = Calendar.current
         let today = Date()
-
+        
         var removedCount = 0
-
+        
         // 31일 이전 ~ 90일 이전 데이터 삭제 (30일 보관 정책)
         for dayOffset in 31...90 {
             guard let oldDate = calendar.date(byAdding: .day, value: -dayOffset, to: today) else { continue }
-
+            
             // UVExposureRecord 삭제
             let exposureKey = exposureKey(for: oldDate)
             if userDefaults.object(forKey: exposureKey) != nil {
                 userDefaults.removeObject(forKey: exposureKey)
                 removedCount += 1
             }
-
+            
             // DailyMEDRecord 삭제
             let medKey = dailyMEDKey(for: oldDate)
             if userDefaults.object(forKey: medKey) != nil {
@@ -366,24 +383,24 @@ final class LocalStorageManager: LocalStorageManagerProtocol {
                 removedCount += 1
             }
         }
-
+        
         Log.info("Cleanup completed: \(removedCount) old records removed")
     }
-
+    
     // MARK: - Private Methods
-
+    
     /// 날짜 포맷터 (yyyyMMdd)
     private static let dateKeyFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyyMMdd"
         return formatter
     }()
-
+    
     /// 날짜별 UVExposure 키 생성
     private func exposureKey(for date: Date) -> String {
         return "exposures.\(Self.dateKeyFormatter.string(from: date))"
     }
-
+    
     /// 날짜별 DailyMED 키 생성
     private func dailyMEDKey(for date: Date) -> String {
         return "dailyMED.\(Self.dateKeyFormatter.string(from: date))"

--- a/StopSun/StopSun/Managers/LocalStorageManager.swift
+++ b/StopSun/StopSun/Managers/LocalStorageManager.swift
@@ -86,6 +86,13 @@ final class LocalStorageManager: LocalStorageManagerProtocol {
         Log.info("Updating SPFLevel to: SPF \(spfLevel.rawValue)")
         saveUserProfile(profile)
     }
+    
+    func updateHasWatch(_ isPaired: Bool) {
+            var profile = loadUserProfileOrDefault()
+            profile.hasWatch = isPaired
+            Log.info("Updating hasWatch to: \(isPaired)")
+            saveUserProfile(profile)
+        }
 
     func deleteUserProfile() {
         userDefaults.removeObject(forKey: profileKey)

--- a/StopSun/StopSun/Managers/Mocks/MockManagers.swift
+++ b/StopSun/StopSun/Managers/Mocks/MockManagers.swift
@@ -53,7 +53,7 @@ final class MockLocationManager: LocationManagerProtocol {
     
     var isAuthorized: Bool { true }
     var isDenied: Bool { false }
-
+    
     func requestAuthorization() async {}
     
     func getCurrentLocation() async throws -> LocationInfo {
@@ -76,7 +76,7 @@ final class MockLocalStorageManager: LocalStorageManagerProtocol {
     private var firstLaunchChecked: Bool = false
     
     // MARK: - UserProfile
-
+    
     func loadUserProfile() -> UserProfile? { userProfile }
     func loadUserProfileOrDefault() -> UserProfile { userProfile ?? .defaultUser }
     func saveUserProfile(_ profile: UserProfile) { userProfile = profile }
@@ -85,6 +85,9 @@ final class MockLocalStorageManager: LocalStorageManagerProtocol {
     }
     func updateSunscreenSPF(_ spfLevel: SPFLevel) {
         userProfile?.spfLevel = spfLevel
+    }
+    func updateHasWatch(_ isPaired: Bool) {
+        userProfile?.hasWatch = isPaired
     }
     func deleteUserProfile() { userProfile = nil }
     func hasUserProfile() -> Bool { userProfile != nil }
@@ -231,51 +234,51 @@ final class MockNotificationManager: NotificationManagerProtocol {
 // MARK: - MockWatchConnectivityManager
 
 final class MockWatchConnectivityManager: WatchConnectivityManagerProtocol {
-
+    
     var _isPaired: Bool = true
-
+    
     var isPaired: Bool { _isPaired }
     var isReachable: Bool { false }
-
+    
     var onMessageReceived: (([String: Any]) -> Void)?
     var onUserInfoReceived: (([String: Any]) -> Void)?
-
+    
     func activate() {}
     func activateAndWait() async {}
     func sendUserProfile(_ profile: UserProfile) {}
     func sendSunscreenApplication(_ application: SunscreenApplication) {}
     func sendMEDStatus(totalSED: Double, maxMED: Double) {}
-
+    
     func sendMessage(
         _ message: [String: Any],
         replyHandler: (([String: Any]) -> Void)?,
         errorHandler: ((Error) -> Void)?
     ) {}
-
+    
     func transferUserInfo(_ userInfo: [String: Any]) {}
     func updateApplicationContext(_ context: [String: Any]) throws {}
 }
 
 @MainActor
 final class MockLiveActivityManager: LiveActivityManagerProtocol {
-
+    
     // MARK: - Properties
-
+    
     var isActivityActive: Bool { _isActivityActive }
-
+    
     private(set) var _isActivityActive = false
     private(set) var lastWarningLevel: WarningLevel?
     private(set) var lastProgress: Double?
     private(set) var lastAppliedAt: Date?
     private(set) var lastReapplyAt: Date?
     private(set) var lastSpfTitle: String?
-
+    
     private(set) var startCallCount = 0
     private(set) var updateCallCount = 0
     private(set) var endCallCount = 0
-
+    
     // MARK: - Methods
-
+    
     func startActivity(
         appliedAt: Date,
         reapplyAt: Date,
@@ -291,21 +294,21 @@ final class MockLiveActivityManager: LiveActivityManagerProtocol {
         lastProgress = progress
         startCallCount += 1
     }
-
+    
     func updateWarningLevel(_ warningLevel: WarningLevel, progress: Double) {
         lastWarningLevel = warningLevel
         lastProgress = progress
         updateCallCount += 1
     }
-
+    
     func endActivity() {
         _isActivityActive = false
         lastWarningLevel = nil
         endCallCount += 1
     }
-
+    
     // MARK: - Test Helper
-
+    
     /// 테스트 시작 전 상태를 초기화하고 싶을 때 사용
     func resetMock() {
         _isActivityActive = false

--- a/StopSun/StopSun/Managers/Mocks/MockManagers.swift
+++ b/StopSun/StopSun/Managers/Mocks/MockManagers.swift
@@ -130,6 +130,21 @@ final class MockLocalStorageManager: LocalStorageManagerProtocol {
         sunscreenHistory.append(application)
     }
     func deleteSunscreen() { sunscreenHistory.removeAll() }
+    
+    private var manualSunscreenStopTime: Date?
+    
+    func saveManualSunscreenStopTime(_ date: Date) {
+        manualSunscreenStopTime = date
+    }
+    
+    func loadManualSunscreenStopTime() -> Date? {
+        return manualSunscreenStopTime
+    }
+    
+    func clearManualSunscreenStopTime() {
+        manualSunscreenStopTime = nil
+    }
+    
     func isSunscreenActive() -> Bool {
         guard let current = sunscreenHistory.last else { return false }
         return current.isActive(at: Date())

--- a/StopSun/StopSun/Managers/Mocks/MockSyncCoordinator.swift
+++ b/StopSun/StopSun/Managers/Mocks/MockSyncCoordinator.swift
@@ -122,6 +122,11 @@ final class MockSyncCoordinator: SyncCoordinatorProtocol {
         userProfile?.spfLevel = spfLevel
     }
     
+    func checkAndUpdateWatchConnection() async {
+        userProfile?.hasWatch = true
+        Log.debug("Mock Watch 연동 확인 — 연결됨")
+    }
+    
     // MARK: - App Lifecycle
     
     func handleAppDidBecomeActive() {

--- a/StopSun/StopSun/Managers/Protocols/LocalStorageManagerProtocol.swift
+++ b/StopSun/StopSun/Managers/Protocols/LocalStorageManagerProtocol.swift
@@ -23,22 +23,22 @@ import Foundation
 protocol LocalStorageManagerProtocol {
     
     // MARK: - UserProfile
-
+    
     /// 사용자 프로필 로드
     func loadUserProfile() -> UserProfile?
-
+    
     /// 사용자 프로필 로드 (없으면 기본값 반환)
     func loadUserProfileOrDefault() -> UserProfile
-
+    
     /// 사용자 프로필 저장
     func saveUserProfile(_ profile: UserProfile)
-
+    
     /// 피부 타입 업데이트
     ///
     /// - Parameter skinType: 새 피부 타입
     /// - Note: 내부에서 NotificationCenter.post 호출
     func updateSkinType(_ skinType: SkinType)
-
+    
     /// 선크림 SPF 업데이트
     ///
     /// - Parameter spfLevel: 새 SPF 레벨
@@ -49,39 +49,51 @@ protocol LocalStorageManagerProtocol {
     ///
     /// - Parameter isPaired: Watch 페어링 여부
     func updateHasWatch(_ isPaired: Bool)
-
+    
+    /// 선크림 수동 종료 시각 저장
+    ///
+    /// `loadActiveSunscreen()`에서 이 시각 이전에 도포된 기록을 제외합니다.
+    /// `applySunscreen()` 호출 시 초기화되어 새 도포가 정상 활성화됩니다.
+    func saveManualSunscreenStopTime(_ date: Date)
+    
+    /// 선크림 수동 종료 시각 조회
+    func loadManualSunscreenStopTime() -> Date?
+    
+    /// 선크림 수동 종료 시각 초기화
+    func clearManualSunscreenStopTime()
+    
     /// 사용자 프로필 삭제
     func deleteUserProfile()
-
+    
     /// 온보딩 완료 상태 저장
     func saveOnboardingCompleted(_ isCompleted: Bool)
-
+    
     /// 온보딩 완료 상태 조회
     func loadOnboardingCompleted() -> Bool
-
+    
     /// 첫 실행 여부 확인
     func checkIsFirstLaunch() -> Bool
     
     // MARK: - SunscreenApplication
-
+    
     /// 선크림 기록 히스토리 로드
     func loadSunscreenHistory() -> [SunscreenApplication]
-
+    
     /// 현재 선크림 로드 (가장 최근 기록)
     func loadCurrentSunscreen() -> SunscreenApplication?
-
+    
     /// 선크림 기록 저장
     func saveSunscreenApplication(_ application: SunscreenApplication)
-
+    
     /// 선크림 기록 삭제
     func deleteSunscreen()
-
+    
     /// 선크림이 활성 상태인지 확인
     func isSunscreenActive() -> Bool
-
+    
     /// 선크림 만료까지 남은 시간 (분)
     func loadSunscreenRemainingMinutes() -> Int
-
+    
     /// 특정 시점에 유효한 SPF 조회
     ///
     /// - Parameter date: 조회할 시점

--- a/StopSun/StopSun/Managers/Protocols/LocalStorageManagerProtocol.swift
+++ b/StopSun/StopSun/Managers/Protocols/LocalStorageManagerProtocol.swift
@@ -44,6 +44,11 @@ protocol LocalStorageManagerProtocol {
     /// - Parameter spfLevel: 새 SPF 레벨
     /// - Note: 내부에서 NotificationCenter.post 호출
     func updateSunscreenSPF(_ spfLevel: SPFLevel)
+    
+    /// Apple Watch 연동 상태 업데이트
+    ///
+    /// - Parameter isPaired: Watch 페어링 여부
+    func updateHasWatch(_ isPaired: Bool)
 
     /// 사용자 프로필 삭제
     func deleteUserProfile()

--- a/StopSun/StopSun/Managers/Protocols/SyncCoordinatorProtocol.swift
+++ b/StopSun/StopSun/Managers/Protocols/SyncCoordinatorProtocol.swift
@@ -78,4 +78,10 @@ protocol SyncCoordinatorProtocol {
     ///
     /// - Parameter spfLevel: 새 SPF 레벨
     func updateSunScreenSPF(_ spfLevel: SPFLevel)
+    
+    /// Apple Watch 연동 상태 확인 및 UserProfile 저장
+    ///
+    /// 온보딩과 동일하게 `activateAndWait()` 후 `isPaired`를 체크하고
+    /// 결과를 `UserProfile.hasWatch`에 반영합니다.
+    func checkAndUpdateWatchConnection() async
 }

--- a/StopSun/StopSun/Managers/SyncCoordinator.swift
+++ b/StopSun/StopSun/Managers/SyncCoordinator.swift
@@ -39,10 +39,10 @@ final class SyncCoordinator: SyncCoordinatorProtocol {
     
     /// 마지막 알림 전송된 경고 레벨 (중복 알림 방지)
     private var lastNotifiedWarningLevel: WarningLevel = .safe
-
+    
     /// 날씨 캐시 TTL (초)
     private static let weatherCacheTTL: TimeInterval = 900  // 15분
-
+    
     // MARK: - Observer Tasks
     @ObservationIgnored
     nonisolated(unsafe) private var observerTasks: [Task<Void, Never>] = []
@@ -56,9 +56,9 @@ final class SyncCoordinator: SyncCoordinatorProtocol {
     private let notification: any NotificationManagerProtocol
     private let watchConnectivity: any WatchConnectivityManagerProtocol
     private let liveActivity: any LiveActivityManagerProtocol
-
+    
     // MARK: - Initializer
-
+    
     init(
         healthKit: any HealthKitManagerProtocol,
         weather: any WeatherManagerProtocol,
@@ -177,18 +177,18 @@ final class SyncCoordinator: SyncCoordinatorProtocol {
         }
         
         Log.info("동기화 시작")
-
+        
         // 0. Watch Connectivity 세션 활성화 (Watch 보유 시에만)
         if userProfile?.hasWatch != false {
             watchConnectivity.activate()
         }
-
+        
         // 1. 프로필 로드
         loadUserProfile()
         
         // 2. 저장된 선크림 상태 로드
         loadActiveSunscreen()
-
+        
         // 3. HealthKit Background Delivery 설정 (Watch 미보유 시에도 수동 입력 감지 필요)
         if healthKit.isAuthorized {
             do {
@@ -336,6 +336,16 @@ final class SyncCoordinator: SyncCoordinatorProtocol {
         Log.info("선호 SPF 변경: \(spfLevel.displayTitle)")
     }
     
+    func checkAndUpdateWatchConnection() async {
+        await watchConnectivity.activateAndWait()
+        
+        let isPaired = watchConnectivity.isPaired
+        localStorage.updateHasWatch(isPaired)
+        userProfile?.hasWatch = isPaired
+        
+        Log.info("Watch 연동 확인 — \(isPaired ? "연결됨" : "미연결")")
+    }
+    
     // MARK: - App Lifecycle
     
     func handleAppDidBecomeActive() {
@@ -366,12 +376,12 @@ private extension SyncCoordinator {
         
         // 첫 sync → 7일 (차트용), 이후 → 3일
         let lookbackDays = lastSyncTime == nil ? 6 : 2
-
+        
         let sunscreenHistory = localStorage.loadSunscreenHistory()
         let locationHistory = localStorage.loadLocationHistory()
-
+        
         var uvCache: [String: Double] = [:]
-
+        
         // 과거 → 오늘 순서로 처리 (오늘이 마지막이어야 todayTotalSED 최종 반영)
         for dayOffset in (0...lookbackDays).reversed() {
             guard let date = calendar.date(byAdding: .day, value: -dayOffset, to: today) else { continue }
@@ -397,38 +407,38 @@ private extension SyncCoordinator {
         let calendar = Calendar.current
         let startOfDay = calendar.startOfDay(for: date)
         let endOfDay = calendar.isDateInToday(date)
-            ? Date()
-            : calendar.date(byAdding: .day, value: 1, to: startOfDay)!
-
+        ? Date()
+        : calendar.date(byAdding: .day, value: 1, to: startOfDay)!
+        
         var cache = uvCache
-
+        
         do {
             let timeInDaylightData = try await healthKit.fetchTimeInDaylight(from: startOfDay, to: endOfDay)
             let existingRecords = localStorage.loadExposureRecords(for: date)
             var runningTotal = existingRecords.reduce(0) { $0 + $1.receivedSED }
-
+            
             let processedIDs = Set(existingRecords.compactMap(\.healthKitID))
-
+            
             var newCount = 0
             var totalMinutes = 0
-
+            
             for data in timeInDaylightData {
                 totalMinutes += Int(data.endTime.timeIntervalSince(data.startTime) / 60)
-
+                
                 if processedIDs.contains(data.id) {
                     continue
                 }
-
+                
                 let locationRecord = locationHistory.last { record in
                     abs(record.timestamp.timeIntervalSince(data.startTime)) < 600
                 }
-
+                
                 let locationInfo = locationRecord?.locationInfo
-                    ?? currentWeather?.location
-                    ?? .mockSeoul
-
+                ?? currentWeather?.location
+                ?? .mockSeoul
+                
                 let cacheKey = "\(String(format: "%.2f", locationInfo.latitude)),\(String(format: "%.2f", locationInfo.longitude))-\(date.toAPIDateString)-\(calendar.component(.hour, from: data.startTime))"
-
+                
                 let uvIndex: Double
                 if let cached = cache[cacheKey] {
                     uvIndex = cached
@@ -441,16 +451,16 @@ private extension SyncCoordinator {
                     }
                     cache[cacheKey] = uvIndex
                 }
-
+                
                 let sed = SEDCalculator.calculateWithSunscreenHistory(
                     start: data.startTime,
                     end: data.endTime,
                     uvIndex: uvIndex,
                     sunscreenHistory: sunscreenHistory
                 )
-
+                
                 let spf = sunscreenHistory.first { $0.isActive(at: data.startTime) }?.spfLevel ?? .none
-
+                
                 let record = UVExposureRecord(
                     healthKitID: data.id,
                     startTime: data.startTime,
@@ -459,23 +469,23 @@ private extension SyncCoordinator {
                     appliedSPF: spf,
                     receivedSED: sed
                 )
-
+                
                 localStorage.saveExposureRecord(record)
-
+                
                 runningTotal += sed
                 newCount += 1
             }
-
+            
             if calendar.isDateInToday(date) {
                 todayTotalSED = runningTotal
             }
-
+            
             var dailyRecord = localStorage.loadDailyMEDRecord(for: date) ?? DailyMEDRecord(date: date)
             dailyRecord.totalSED = runningTotal
             dailyRecord.recordCount = existingRecords.count + newCount
             dailyRecord.totalExposureMinutes = totalMinutes
             localStorage.saveDailyMEDRecord(dailyRecord)
-
+            
             if newCount > 0 {
                 Log.info("\(date.toDateString) SED 계산: \(String(format: "%.2f", runningTotal)), 새로 처리 \(newCount)건")
             }
@@ -485,7 +495,7 @@ private extension SyncCoordinator {
                 self.error = .healthKit(.dataFetchFailed)
             }
         }
-
+        
         return cache
     }
 }
@@ -707,13 +717,13 @@ private extension SyncCoordinator {
     /// 과거 UV 조회 시 위치 정보를 활용할 수 있도록 합니다.
     /// 날씨가 한 번도 성공하지 못한 경우에만 서울 기본값으로 대체합니다.
     func fetchCurrentLocationAndWeather() async {
-
+        
         if let weather = currentWeather,
            Date().timeIntervalSince(weather.fetchedAt) < Self.weatherCacheTTL {
             Log.debug("날씨 캐시 유효 (\(Int(Date().timeIntervalSince(weather.fetchedAt)))초 경과), API 스킵")
             return
         }
-
+        
         do {
             let locationInfo = try await location.getCurrentLocation()
             

--- a/StopSun/StopSun/Managers/SyncCoordinator.swift
+++ b/StopSun/StopSun/Managers/SyncCoordinator.swift
@@ -279,6 +279,7 @@ final class SyncCoordinator: SyncCoordinatorProtocol {
         )
         
         localStorage.saveSunscreenApplication(application)
+        localStorage.clearManualSunscreenStopTime()
         activeSunscreen = application
         
         let reapplyTime = application.nextReapplyTime
@@ -307,6 +308,7 @@ final class SyncCoordinator: SyncCoordinatorProtocol {
     
     func stopSunscreen() {
         activeSunscreen = nil
+        localStorage.saveManualSunscreenStopTime(Date())
         notification.cancelReapplyReminder()
         liveActivity.endActivity()
         Log.info("선크림 타이머 종료")
@@ -704,10 +706,18 @@ private extension SyncCoordinator {
     }
     
     func loadActiveSunscreen() {
+        let stopTime = localStorage.loadManualSunscreenStopTime()
+        
         activeSunscreen = localStorage.loadSunscreenHistory()
             .filter { $0.isActive(at: Date()) }
+            .filter { record in
+                // 수동 종료 시각 이후에 도포된 기록만 유효
+                guard let stopTime else { return true }
+                return record.appliedAt > stopTime
+            }
             .sorted { $0.appliedAt > $1.appliedAt }
             .first
+        
         Log.debug("활성 선크림: \(activeSunscreen != nil ? "있음" : "없음")")
     }
     

--- a/StopSun/StopSun/ViewModels/DashboardViewModel.swift
+++ b/StopSun/StopSun/ViewModels/DashboardViewModel.swift
@@ -17,9 +17,9 @@ import Foundation
 @Observable
 final class DashboardViewModel {
     // MARK: - View State
-
+    
     var currentPage: Int = 0
-
+    
     /// Watch 미보유 시 MED 자동 추적 불가 → 선크림 타이머 중심 UI
     var hasWatch: Bool {
         syncCoordinator.userProfile?.hasWatch ?? true
@@ -28,11 +28,11 @@ final class DashboardViewModel {
     /// 캐싱된 날짜 문자열 (하루에 한 번만 갱신)
     private(set) var formattedDate: String = ""
     private(set) var weeklyChartItems: [WeeklyBarItem] = []
-
+    
     // MARK: - Private Cache State
-
+    
     private var lastBuiltDate: Date?
-
+    
     // MARK: - Dependencies
     
     private let syncCoordinator: SyncCoordinator
@@ -72,87 +72,102 @@ final class DashboardViewModel {
     var warningLevel: WarningLevel {
         syncCoordinator.warningLevel
     }
-
+    
     /// SyncCoordinator 에러 (ErrorHandler 연결용)
     var syncError: AppError? {
         syncCoordinator.error
     }
-
+    
     // MARK: - Weather Data
-
+    
     var uvIndex: Int {
         Int(syncCoordinator.currentWeather?.currentUVIndex ?? 0)
     }
-
+    
     var temperature: Double {
         syncCoordinator.currentWeather?.currentTemperature ?? 0
     }
-
+    
     var locationName: String {
         syncCoordinator.currentWeather?.location.cityName ?? "—"
     }
-
+    
     // MARK: - Sunscreen Timer
-
+    
     var isTimerActive: Bool {
         guard let sunscreen = syncCoordinator.activeSunscreen else { return false }
         return sunscreen.isActive(at: Date())
     }
-
+    
     func timerRemaining(at now: Date) -> String {
         guard let sunscreen = syncCoordinator.activeSunscreen,
               sunscreen.isActive(at: now)
         else {
             return "00:00"
         }
-
+        
         let remaining = sunscreen.nextReapplyTime.timeIntervalSince(now)
         guard remaining > 0 else { return "00:00" }
-
+        
         let hours = Int(remaining) / 3600
         let minutes = (Int(remaining) % 3600) / 60
         let seconds = Int(remaining) % 60
-
+        
         if hours > 0 {
             return String(format: "%d:%02d:%02d", hours, minutes, seconds)
         } else {
             return String(format: "%02d:%02d", minutes, seconds)
         }
     }
-
+    
     // MARK: - Actions
-
+    
     func onAppear() async {
         formattedDate = Date().toDayWithWeekdayString
-
+        
         // Watch 미보유 시 선크림 타이머 카드를 기본으로
         if !hasWatch && currentPage == 0 {
             currentPage = 1
         }
         refreshWeeklyChartItemsIfNeeded()
-
+        
         guard let lastSync = syncCoordinator.lastSyncTime else {
             await syncCoordinator.startSync()
             refreshWeeklyChartItems()
             return
         }
-
+        
         if Date().timeIntervalSince(lastSync) > resyncInterval {
             await syncCoordinator.startSync()
             refreshWeeklyChartItems()
         }
     }
-
+    
     func pullToRefresh() async {
         await syncCoordinator.refresh()
         refreshWeeklyChartItems()
     }
-
+    
+    // MARK: - Sunscreen Timer Actions
+    
+    /// 저장된 SPF로 선크림 타이머 시작
+    func applySunscreen() {
+        let spf = syncCoordinator.userProfile?.spfLevel ?? .spf30
+        syncCoordinator.applySunscreen(spf: spf)
+        Log.info("Dashboard: 선크림 도포 (SPF \(spf.displayTitle))")
+    }
+    
+    /// 선크림 타이머 종료
+    func stopSunscreen() {
+        syncCoordinator.stopSunscreen()
+        Log.info("Dashboard: 선크림 타이머 종료")
+    }
+    
     // MARK: - Weekly Chart
-
+    
     private func refreshWeeklyChartItemsIfNeeded() {
         let today = Calendar.current.startOfDay(for: Date())
-
+        
         guard let lastBuilt = lastBuiltDate,
               Calendar.current.isDate(lastBuilt, inSameDayAs: today)
         else {
@@ -160,26 +175,26 @@ final class DashboardViewModel {
             refreshWeeklyChartItems()
             return
         }
-
+        
         // 같은 날이면 오늘 항목만 업데이트
         updateTodayItem()
     }
-
+    
     private func refreshWeeklyChartItems() {
         weeklyChartItems = buildWeeklyChartItems()
         lastBuiltDate = Calendar.current.startOfDay(for: Date())
     }
-
+    
     private func updateTodayItem() {
         guard !weeklyChartItems.isEmpty,
               let skinType = syncCoordinator.userProfile?.skinType
         else { return }
-
+        
         let maxSED = skinType.maxDailyMEDinSED
         let percent = maxSED > 0 ? (syncCoordinator.todayTotalSED / maxSED) * 100 : 0
         let today = Calendar.current.startOfDay(for: Date())
         let minutes = localStorage.loadDailyMEDRecord(for: today)?.totalExposureMinutes ?? 0
-
+        
         weeklyChartItems[6] = WeeklyBarItem(
             dayLabel: weeklyChartItems[6].dayLabel,
             percent: percent,
@@ -187,17 +202,17 @@ final class DashboardViewModel {
             isToday: true
         )
     }
-
+    
     private func buildWeeklyChartItems() -> [WeeklyBarItem] {
         let calendar = Calendar.current
         let today = calendar.startOfDay(for: Date())
-
+        
         let isEnglish = Locale.current.language.languageCode?.identifier == "en"
         let daySymbols = isEnglish
-            ? ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"]
-            : ["일", "월", "화", "수", "목", "금", "토"]
+        ? ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"]
+        : ["일", "월", "화", "수", "목", "금", "토"]
         let todayLabel = isEnglish ? "TODAY" : "오늘"
-
+        
         guard let skinType = syncCoordinator.userProfile?.skinType else {
             return (0..<7).map { offset in
                 let date = calendar.date(byAdding: .day, value: offset - 6, to: today)!
@@ -210,35 +225,35 @@ final class DashboardViewModel {
                 )
             }
         }
-
+        
         let maxSED = skinType.maxDailyMEDinSED
-
+        
         return (0..<7).map { offset in
             let date = calendar.date(byAdding: .day, value: offset - 6, to: today)!
             let weekday = calendar.component(.weekday, from: date) - 1
             let isToday = offset == 6
             let label = isToday ? todayLabel : daySymbols[weekday]
-
+            
             if isToday {
                 let percent = maxSED > 0 ? (syncCoordinator.todayTotalSED / maxSED) * 100 : 0
                 let minutes = localStorage.loadDailyMEDRecord(for: date)?.totalExposureMinutes ?? 0
                 return WeeklyBarItem(dayLabel: label, percent: percent, exposureMinutes: minutes, isToday: true)
             }
-
+            
             if let record = localStorage.loadDailyMEDRecord(for: date) {
                 let percent = maxSED > 0 ? (record.totalSED / maxSED) * 100 : 0
                 return WeeklyBarItem(dayLabel: label, percent: percent, exposureMinutes: record.totalExposureMinutes, isToday: false)
             }
-
+            
             return WeeklyBarItem(dayLabel: label, percent: 0, exposureMinutes: 0, isToday: false)
         }
     }
-
+    
     // MARK: - Debug
     
-    #if DEBUG
-        var debugSyncCoordinator: SyncCoordinator {
-            syncCoordinator
-        }
-    #endif
+#if DEBUG
+    var debugSyncCoordinator: SyncCoordinator {
+        syncCoordinator
+    }
+#endif
 }

--- a/StopSun/StopSun/ViewModels/SettingsViewModel.swift
+++ b/StopSun/StopSun/ViewModels/SettingsViewModel.swift
@@ -33,8 +33,17 @@ final class SettingsViewModel {
     
     // MARK: - Watch
     
+    /// Watch 연동 확인 결과
+    enum WatchConnectionResult {
+        case alreadyConnected   // 확인 전부터 이미 연결 상태
+        case nowConnected       // 확인 후 새로 연결됨
+        case notPaired          // 페어링된 워치 없음
+    }
+    
     /// Watch 연동 확인 진행 중 여부
     private(set) var isCheckingWatch: Bool = false
+    private(set) var watchConnectionResult: WatchConnectionResult?
+    var showWatchConnectionAlert: Bool = false
     
     // MARK: - Dependencies
     
@@ -93,7 +102,18 @@ final class SettingsViewModel {
         isCheckingWatch = true
         defer { isCheckingWatch = false }
         
+        let wasConnected = hasWatch  // 체크 전 상태 캡처
+        
         await syncCoordinator.checkAndUpdateWatchConnection()
+        
+        // hasWatch는 checkAndUpdateWatchConnection() 완료 후 자동 반영 (@Observable)
+        if hasWatch {
+            watchConnectionResult = wasConnected ? .alreadyConnected : .nowConnected
+        } else {
+            watchConnectionResult = .notPaired
+        }
+        showWatchConnectionAlert = true
+        
         Log.info("Settings: Watch 연동 확인 완료 — \(hasWatch ? "연결됨" : "미연결")")
     }
     

--- a/StopSun/StopSun/ViewModels/SettingsViewModel.swift
+++ b/StopSun/StopSun/ViewModels/SettingsViewModel.swift
@@ -31,6 +31,11 @@ final class SettingsViewModel {
     private(set) var skinType: SkinType
     private(set) var spfLevel: SPFLevel
     
+    // MARK: - Watch
+    
+    /// Watch 연동 확인 진행 중 여부
+    private(set) var isCheckingWatch: Bool = false
+    
     // MARK: - Dependencies
     
     private let syncCoordinator: any SyncCoordinatorProtocol
@@ -79,6 +84,19 @@ final class SettingsViewModel {
         Log.debug("Settings: Profile refreshed")
     }
     
+    /// Apple Watch 연동 확인
+    ///
+    /// 온보딩과 동일하게 `activateAndWait()` → `isPaired` 체크 후
+    /// `UserProfile.hasWatch`에 저장합니다.
+    func checkWatchConnection() async {
+        guard !isCheckingWatch else { return }
+        isCheckingWatch = true
+        defer { isCheckingWatch = false }
+        
+        await syncCoordinator.checkAndUpdateWatchConnection()
+        Log.info("Settings: Watch 연동 확인 완료 — \(hasWatch ? "연결됨" : "미연결")")
+    }
+    
     // MARK: - Display Helpers
     
     var skinTypeDisplayText: String { skinType.title }
@@ -105,13 +123,13 @@ final class SettingsViewModel {
     var hasWatch: Bool {
         syncCoordinator.userProfile?.hasWatch ?? true
     }
-
+    
     /// 설정 앱으로 이동
     func openAppSettings() {
         guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
         UIApplication.shared.open(url)
     }
-
+    
     /// 건강 앱 (일광 시간) 열기
     func openHealthApp() {
         guard let url = URL(string: "x-apple-health://") else { return }

--- a/StopSun/StopSun/Views/Dashboard/DashboardView.swift
+++ b/StopSun/StopSun/Views/Dashboard/DashboardView.swift
@@ -184,7 +184,9 @@ struct DashboardView: View {
         TimelineView(.periodic(from: .now, by: 1)) { context in
             SunscreenTimerCardView(
                 remainingTime: viewModel.timerRemaining(at: context.date),
-                isTimerActive: viewModel.isTimerActive
+                isTimerActive: viewModel.isTimerActive,
+                onStart: { viewModel.applySunscreen() },
+                onStop: { viewModel.stopSunscreen() }
             )
         }
     }

--- a/StopSun/StopSun/Views/Dashboard/Subview/SunscreenTimerCardView.swift
+++ b/StopSun/StopSun/Views/Dashboard/Subview/SunscreenTimerCardView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 /// 선크림 타이머 카드
 ///
-/// - 비활성 상태: "선크림을 도포해주세요" + 도포 버튼
+/// - 비활성 상태: "선크림을 다시 바를 수 있도록 알려줄게요" + 도포 버튼
 /// - 활성 상태: 남은 시간 카운트다운 + 종료 버튼
 struct SunscreenTimerCardView: View {
 
@@ -26,7 +26,7 @@ struct SunscreenTimerCardView: View {
                     .foregroundStyle(.key00)
 
                 Text(isTimerActive ? remainingTime : L10n.Sunscreen.Card.inactive)
-                    .font(.ssFont(.SB5))
+                    .font(isTimerActive ? .ssFont(.SB5) : .ssFont(.SB1))
                     .multilineTextAlignment(.center)
                     .foregroundStyle(.key00)
             }

--- a/StopSun/StopSun/Views/Dashboard/Subview/SunscreenTimerCardView.swift
+++ b/StopSun/StopSun/Views/Dashboard/Subview/SunscreenTimerCardView.swift
@@ -7,33 +7,41 @@
 
 import SwiftUI
 
-struct SunscreenTimerCardView:
-    View {
-    
+/// 선크림 타이머 카드
+///
+/// - 비활성 상태: "선크림을 도포해주세요" + 도포 버튼
+/// - 활성 상태: 남은 시간 카운트다운 + 종료 버튼
+struct SunscreenTimerCardView: View {
+
     let remainingTime: String
     let isTimerActive: Bool
-    
+    let onStart: () -> Void
+    let onStop: () -> Void
+
     var body: some View {
         VStack(alignment: .center, spacing: 24) {
-            VStack {
-                // 날씨 아이콘
+            VStack(spacing: 8) {
                 Image(systemName: "cloud.sun")
                     .font(.system(size: 32))
                     .foregroundStyle(.key00)
-                
-                // 타이머
-                Text(remainingTime)
+
+                Text(isTimerActive ? remainingTime : L10n.Sunscreen.Card.inactive)
                     .font(.ssFont(.SB5))
                     .multilineTextAlignment(.center)
                     .foregroundStyle(.key00)
             }
 
-            // 안내 문구
-            Text(L10n.Sunscreen.Card.watchPrompt)
-                .font(.ssFont(.M2))
-                .multilineTextAlignment(.center)
-                .foregroundStyle(.text02)
-            
+            if isTimerActive {
+                SSButton(L10n.Sunscreen.Card.stop, style: .secondary) {
+                    onStop()
+                }
+                .padding(.horizontal, 20)
+            } else {
+                SSButton(L10n.Sunscreen.Card.start, style: .primary) {
+                    onStart()
+                }
+                .padding(.horizontal, 20)
+            }
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 32)
@@ -43,7 +51,9 @@ struct SunscreenTimerCardView:
 #Preview("Timer 비활성") {
     SunscreenTimerCardView(
         remainingTime: "00:00",
-        isTimerActive: false
+        isTimerActive: false,
+        onStart: {},
+        onStop: {}
     )
     .padding()
     .background(Color.gray.opacity(0.1))
@@ -52,7 +62,9 @@ struct SunscreenTimerCardView:
 #Preview("Timer 활성") {
     SunscreenTimerCardView(
         remainingTime: "01:32",
-        isTimerActive: true
+        isTimerActive: true,
+        onStart: {},
+        onStop: {}
     )
     .padding()
     .background(Color.gray.opacity(0.1))

--- a/StopSun/StopSun/Views/Setting/SettingsView.swift
+++ b/StopSun/StopSun/Views/Setting/SettingsView.swift
@@ -66,6 +66,13 @@ struct SettingsView: View {
             .sheet(item: $selectedURL) { item in
                 SafariView(url: item.url)
             }
+            .alert(watchAlertTitle, isPresented: $viewModel.showWatchConnectionAlert) {
+                Button(L10n.Button.confirm) {
+                    viewModel.showWatchConnectionAlert = false
+                }
+            } message: {
+                Text(watchAlertMessage)
+            }
         }
     }
     
@@ -309,6 +316,26 @@ struct SettingsView: View {
         .frame(maxWidth: .infinity)
         .padding(.top, 28)
         .padding(.bottom, 40)
+    }
+    
+    // MARK: - Watch Alert Helpers
+    
+    private var watchAlertTitle: String {
+        switch viewModel.watchConnectionResult {
+        case .alreadyConnected: return L10n.Settings.WatchAlert.alreadyConnectedTitle
+        case .nowConnected:     return L10n.Settings.WatchAlert.connectedTitle
+        case .notPaired:        return L10n.Settings.WatchAlert.notPairedTitle
+        case nil:               return ""
+        }
+    }
+    
+    private var watchAlertMessage: String {
+        switch viewModel.watchConnectionResult {
+        case .alreadyConnected: return L10n.Settings.WatchAlert.alreadyConnectedMessage
+        case .nowConnected:     return L10n.Settings.WatchAlert.connectedMessage
+        case .notPaired:        return L10n.Settings.WatchAlert.notPairedMessage
+        case nil:               return ""
+        }
     }
     
     // MARK: - Watch Connection Trailing

--- a/StopSun/StopSun/Views/Setting/SettingsView.swift
+++ b/StopSun/StopSun/Views/Setting/SettingsView.swift
@@ -107,11 +107,20 @@ struct SettingsView: View {
                     showHealthKitGuide = true
                 }
             )
-
+            
+            Spacer().frame(height: 24)
+            
+            // Apple Watch 연동 확인
+            settingsRow(
+                title: L10n.Settings.WatchSetting.title,
+                description: L10n.Settings.WatchSetting.desc,
+                trailing: watchConnectionTrailing
+            )
+            
             // Watch 미보유 시: 건강 앱에서 일광 시간 수동 기록 안내
             if !viewModel.hasWatch {
                 Spacer().frame(height: 24)
-
+                
                 settingsRow(
                     title: L10n.Settings.Daylight.title,
                     description: L10n.Settings.Daylight.desc,
@@ -271,8 +280,8 @@ struct SettingsView: View {
             
             SSButton(
                 healthKitGuideStep < steps.count - 1
-                    ? L10n.Button.next
-                    : L10n.Button.confirm,
+                ? L10n.Button.next
+                : L10n.Button.confirm,
                 style: .primary
             ) {
                 if healthKitGuideStep < steps.count - 1 {
@@ -300,6 +309,26 @@ struct SettingsView: View {
         .frame(maxWidth: .infinity)
         .padding(.top, 28)
         .padding(.bottom, 40)
+    }
+    
+    // MARK: - Watch Connection Trailing
+    
+    @ViewBuilder
+    private var watchConnectionTrailing: some View {
+        if viewModel.isCheckingWatch {
+            ProgressView()
+                .tint(Color.key00)
+        } else {
+            HStack(spacing: 6) {
+                Circle()
+                    .fill(viewModel.hasWatch ? Color.gage00 : Color.text03)
+                    .frame(width: 6, height: 6)
+                
+                linkButton(L10n.Settings.WatchSetting.check) {
+                    Task { await viewModel.checkWatchConnection() }
+                }
+            }
+        }
     }
     
     // MARK: - Reusable Components


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

Closed #112 

## ✨ What’s this PR?

- Watch 미보유 사용자 UX 개선 및 선크림 재활성화 버그 수정.
- 
### 🧶 주요 변경 내용
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->


### Commit 1 — LocalStorage Watch 연동 상태 저장

이후 Watch 연동 확인 결과를 저장하기 위한 사전 인프라.

- `LocalStorageManagerProtocol` — `updateHasWatch(_:)` 추가
- `LocalStorageManager` — 구현
- `MockLocalStorageManager` — Mock 추가

---

### Commit 2 — 설정 > 애플 워치 연동 확인

온보딩의 Watch 페어링 체크 로직(`activateAndWait()` → `isPaired`)을
설정 화면에서도 동일하게 실행하고 결과를 `UserProfile.hasWatch`에 저장.

**흐름**
확인 버튼 탭
→ SettingsViewModel.checkWatchConnection()
→ SyncCoordinator.checkAndUpdateWatchConnection()
→ WatchConnectivityManager.activateAndWait()
→ isPaired 확인
→ LocalStorage.updateHasWatch(_:)
→ userProfile?.hasWatch 갱신
→ UI 자동 반영 (@Observable)

- `SyncCoordinatorProtocol` / `SyncCoordinator` — `checkAndUpdateWatchConnection()` 추가
- `MockSyncCoordinator` — Mock 추가
- `SettingsViewModel` — `isCheckingWatch`, `checkWatchConnection()` 추가
- `SettingsView` — 서비스 설정 섹션 Watch 연동 확인 row 추가
  - 확인 중: `ProgressView`
  - 확인 후: 상태 dot (연결됨 `gage00` / 미연결 `text03`) + 확인 버튼

---

### Commit 2-A — 선크림 수동 종료 시 재활성화 버그

**원인**

`stopSunscreen()`이 메모리(`activeSunscreen = nil`)만 초기화하고
LocalStorage 레코드는 그대로 유지했기 때문에,
이후 `refresh()` 또는 앱 재진입 시 `loadActiveSunscreen()`이
아직 `isActive = true`인 레코드를 재로드해 타이머가 살아나는 문제.

**해결**

수동 종료 시각을 별도 키로 저장하고 `loadActiveSunscreen()` 에서 필터링.
SED 계산에 필요한 히스토리는 보존.
stopSunscreen()
→ saveManualSunscreenStopTime(Date())
loadActiveSunscreen()
→ loadSunscreenHistory()
→ filter { isActive }
→ filter { appliedAt > manualStopTime }   ← 추가
applySunscreen()
→ clearManualSunscreenStopTime()          ← 새 도포 시 초기화
→ 이하 기존 동일

**Watch 연동 충돌 없음**

Watch 도포/종료 모두 `applySunscreen()` / `stopSunscreen()` 을 공유하며,
`appliedAt` 은 항상 iPhone 수신 시각(`Date()`)이므로
stopTime 대소 비교가 정확하게 동작.

- `LocalStorageManagerProtocol` — `saveManualSunscreenStopTime(_:)`, `loadManualSunscreenStopTime()`, `clearManualSunscreenStopTime()` 추가
- `LocalStorageManager` — `sunscreenManualStopKey` 추가 + 구현 3개
- `MockLocalStorageManager` — Mock 3개 추가
- `SyncCoordinator.stopSunscreen()` — `saveManualSunscreenStopTime` 추가
- `SyncCoordinator.applySunscreen()` — `clearManualSunscreenStopTime` 추가
- `SyncCoordinator.loadActiveSunscreen()` — stopTime 필터 추가

---

### Commit 2-B — 설정 Watch 연동 확인 결과 Alert

연동 확인 완료 후 결과를 3가지 상태로 Alert 표시.

| 상태 | 조건 | 제목 |
|------|------|------|
| `alreadyConnected` | 확인 전부터 연결 상태 | 이미 연결되어 있어요 |
| `nowConnected` | 확인 후 새로 연결됨 | 연결됐어요 |
| `notPaired` | 페어링 기기 없음 | 워치가 연결되지 않았어요 |

- `SettingsViewModel` — `WatchConnectionResult` enum + `watchConnectionResult`, `showWatchConnectionAlert` 추가, `checkWatchConnection()` 수정
- `SettingsView` — `.alert` 추가, `watchAlertTitle` / `watchAlertMessage` 헬퍼 추가

---

### Commit 3 — 대시보드 선크림 타이머 iOS 직접 조작

Watch 보유 여부와 무관하게 iOS에서도 타이머 직접 조작 가능.
시작 시 프로필에 저장된 SPF 자동 사용 (설정 > SPF 기준).

**상태별 UI**
- 비활성: 도포 안내 문구 + Primary 버튼 ("선크림 도포")
- 활성: 남은 시간 카운트다운 + Secondary 버튼 ("타이머 종료")

- `DashboardViewModel` — `applySunscreen()`, `stopSunscreen()` 추가
- `SunscreenTimerCardView` — `onStart` / `onStop` 클로저 추가, 상태별 UI 분기
- `DashboardView` — `sunscreenTimerCard` 에 액션 전달


---

### 📸 스크린샷 
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

**Watch 연동 확인**
- [ ] 확인 버튼 탭 시 `ProgressView` 노출
- [ ] 페어링 기기 있음 → `alreadyConnected` 또는 `nowConnected` Alert
- [ ] 페어링 기기 없음 → `notPaired` Alert
- [ ] Alert 확인 후 상태 dot 색상 반영 확인

**선크림 재활성화 버그**
- [ ] 타이머 시작 → 종료 → `pullToRefresh` → 타이머 비활성 유지 확인
- [ ] 타이머 시작 → 종료 → 앱 재진입 → 타이머 비활성 유지 확인
- [ ] 종료 후 새 도포 → 정상 활성화 확인
- [ ] Watch에서 도포 → iOS에서 종료 → 재활성화 없음 확인

**선크림 타이머 iOS 조작**
- [ ] 비활성 상태 → 도포 버튼 탭 → 카운트다운 시작
- [ ] 활성 상태 → 종료 버튼 탭 → 타이머 초기화
- [ ] 도포 시 설정에 저장된 SPF 자동 적용 확인
- [ ] Watch 보유 / 미보유 모두 동일하게 동작

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- UI 컴포넌트 위치가 디자이너 시안과 다를 수 있어요 → 후속 PR에서 반영 예정
- API 에러 대응 로직은 공통 모듈화하는 작업과 함께 처리할 예정입니다
